### PR TITLE
fix: suppress transient mode flap after SET (#102)

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -174,6 +174,7 @@ void ClimateMideaXYE::update() {
   switch (controlState) {
     case ControlState::SEND_SET: {
       setTransmitParams();
+      post_set_grace_ = 2;
       cmdSent = CLIENT_COMMAND_SET;
       sendRecv(cmdSent);
       break;
@@ -234,9 +235,16 @@ void ClimateMideaXYE::ParseResponse() {
 
       bool need_publish = false;
 
-      update_property(this->mode, mode, need_publish);
-      if (mode != ClimateMode::CLIMATE_MODE_OFF) {
-        this->last_on_mode_ = mode;
+      if (post_set_grace_ > 0) {
+        post_set_grace_--;
+        ESP_LOGD(Constants::TAG,
+                 "Post-SET grace: ignoring reported mode=%d (%u cycle(s) remaining)",
+                 static_cast<int>(mode), post_set_grace_);
+      } else {
+        update_property(this->mode, mode, need_publish);
+        if (mode != ClimateMode::CLIMATE_MODE_OFF) {
+          this->last_on_mode_ = mode;
+        }
       }
 
       if (mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) {

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -180,6 +180,10 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   // When true, Follow-Me updates send a regular UPDATE subcommand (0x02).
   bool followMeInit;
   uint8_t lastFollowMeTemperature;
+  // Number of upcoming QUERY responses whose reported mode should be
+  // ignored after we issue a SET. Prevents a transient mode flap
+  // (e.g. cool -> off -> cool) while the unit acknowledges the new mode.
+  uint8_t post_set_grace_{0};
 
  protected:
   uart::UARTComponent *uart_;


### PR DESCRIPTION
## Summary

- After a `ClimateCall` issues `SEND_SET`, the unit sometimes answers the next `QUERY` with the old mode before acknowledging the new one, producing a brief `cool -> off -> cool` (or `heat -> off -> heat`) flap in `hvac_mode` while `hvac_action` stays put.
- Add a `post_set_grace_` counter that ignores the reported mode on the next two QUERY responses after a SET, letting the unit settle. Temperature and fan continue to update, so no telemetry is lost.

Closes #102

## Test plan

- [ ] Compile-check with ESPHome (existing YAML tests under `tests/`).
- [ ] Flash a unit and trigger mode changes (off→cool, cool→off, off→heat) via Home Assistant; confirm `hvac_mode` transitions cleanly with no intermediate `off` flap.
- [ ] Verify a debug log line `Post-SET grace: ignoring reported mode=...` appears for up to two cycles after each SET.
- [ ] Verify normal operation (no SET in flight) still updates `mode` from QUERY responses as before.