### PR TITLE
feat!: migrate to ESPHome 2026.4.0 custom-mode API (#100)

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -62,6 +62,11 @@ void ClimateMideaXYE::setup() {
   ForceReadNextCycle = 1;
   followMeInit = false;
 
+  // Register custom modes on the Climate base class. ESPHome 2026.4.0
+  // deprecated the equivalent ClimateTraits setters in favor of these.
+  this->set_supported_custom_presets(this->supported_custom_presets_);
+  this->set_supported_custom_fan_modes(this->supported_custom_fan_modes_);
+
   // Start up in Auto fan mode (since unit doesn't report it correctly)
   this->fan_mode = ClimateFanMode::CLIMATE_FAN_AUTO;
 }
@@ -406,8 +411,6 @@ climate::ClimateTraits ClimateMideaXYE::traits() {
   traits.set_supported_modes(this->supported_modes_);
   traits.set_supported_swing_modes(this->supported_swing_modes_);
   traits.set_supported_presets(this->supported_presets_);
-  traits.set_supported_custom_presets(this->supported_custom_presets_);
-  traits.set_supported_custom_fan_modes(this->supported_custom_fan_modes_);
   /* + MINIMAL SET OF CAPABILITIES */
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_AUTO);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_LOW);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Python requirements for ESPHome component development and CI
-esphome==2026.3.2
+esphome==2026.4.0


### PR DESCRIPTION
## Summary

- ESPHome 2026.4.0 moved custom fan-mode / preset setters from `ClimateTraits` to the `Climate` entity base class ([esphome/esphome#15206](https://github.com/esphome/esphome/pull/15206)). The old `ClimateTraits::set_supported_custom_{presets,fan_modes}()` setters are deprecated in 2026.4.0 and removed in 2026.11.0.
- Call `this->set_supported_custom_{presets,fan_modes}(...)` once in `setup()` on the base class instead of copying the vectors into `traits` on every `publish_state()`.
- Bump `requirements.txt` from `2026.3.2` → `2026.4.0`.

Closes #100

## Breaking change

Users pulling this as `external_components` with an ESPHome older than 2026.4.0 will fail to compile. The deprecated traits setters would still work on 2026.4.0–2026.11.0, but we migrate now to keep the codebase on supported APIs and avoid bundling this with unrelated work closer to 2026.11.0.

## Test plan

- [ ] `esphome compile tests/midea_xye.yaml` passes with `esphome==2026.4.0`.
- [ ] `esphome compile tests/midea_xye_esp32.yaml` passes.
- [ ] Flash a unit; confirm custom presets (`Boost`, `Sleep`) and custom fan modes still surface in Home Assistant UI.
- [ ] Confirm no deprecation warnings from ESPHome during compile.