### PR TITLE
docs: correct contributor credit from @rymo to @rmounce (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Kudos to these projects and people:
 - Fully integrated Midea Climate component: https://github.com/esphome/esphome/tree/dev/esphome/components/midea
 - ESPHome external component foundation by @exciton: https://github.com/exciton/esphome
 - Key contributions and inspiration by @mdrobnak: https://github.com/mdrobnak/esphome/tree/units_switch
-- Static pressure protocol analysis by @rymo
+- Static pressure protocol analysis by @rmounce
 - Home Assistant community discussion and contributions: https://community.home-assistant.io/t/midea-a-c-via-local-xye/857679
 
 ## Hardware Requirements


### PR DESCRIPTION
## Summary

- `README.md:20` credited the static-pressure protocol analysis to `@rymo`, but that GitHub handle belongs to a different user who did not contribute. The actual contributor is `@rmounce`, whose Home Assistant community forum handle is `rymo`.
- Other `rymo` references in `esphome/components/midea_xye/PROTOCOL.md` are bare text (not GitHub @mentions) and refer to the forum handle as cited in the linked HA community thread — left as-is.

Closes #99

## Test plan

- [ ] Preview rendered README on GitHub and confirm the link resolves to `@rmounce`, not `@rymo`.