### PR TITLE
feat: add defrost active binary sensor (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ climate:
       name: Error Flags
     protect_flags:              # Optional
       name: Protect Flags
+    defrost:                    # Optional. True while the indoor unit is running a defrost cycle
+      name: Defrost Active
 ```
 
 ## Debugging

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -1,6 +1,6 @@
 from esphome.core import coroutine
 from esphome import automation
-from esphome.components import climate, sensor, uart, remote_transmitter, number
+from esphome.components import binary_sensor, climate, sensor, uart, remote_transmitter, number
 from esphome.components.remote_base import CONF_TRANSMITTER_ID
 import esphome.config_validation as cv
 import esphome.codegen as cg
@@ -26,6 +26,7 @@ from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_DURATION,
     DEVICE_CLASS_EMPTY,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_POWER,
     ICON_THERMOMETER,
     ICON_WATER_PERCENT,
@@ -48,7 +49,7 @@ from esphome.components.climate import (
 
 #CODEOWNERS = ["@dudanov"]
 DEPENDENCIES = ["climate", "uart", "wifi"]
-AUTO_LOAD = ["number", "sensor"]
+AUTO_LOAD = ["binary_sensor", "number", "sensor"]
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
 CONF_TEMPERATURE_2A = "temperature_2a"
 CONF_TEMPERATURE_2B = "temperature_2b"
@@ -63,6 +64,7 @@ CONF_HUMIDITY_SETPOINT = "humidity_setpoint"
 CONF_STATIC_PRESSURE = "static_pressure"
 CONF_FOLLOW_ME_SENSOR = "follow_me_sensor"
 CONF_INTERNAL_CURRENT_TEMPERATURE = "internal_current_temperature"
+CONF_DEFROST = "defrost"
 midea_xye_ns = cg.esphome_ns.namespace("midea").namespace("xye")
 ClimateMideaXYE = midea_xye_ns.class_("ClimateMideaXYE", climate.Climate, cg.Component)
 StaticPressureNumber = midea_xye_ns.class_("StaticPressureNumber", number.Number, cg.Component)
@@ -242,6 +244,10 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_DEFROST): binary_sensor.binary_sensor_schema(
+                icon="mdi:snowflake-thermometer",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         }
     )
@@ -424,3 +430,6 @@ async def to_code(config):
     if CONF_INTERNAL_CURRENT_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_INTERNAL_CURRENT_TEMPERATURE])
         cg.add(var.set_internal_current_temperature_sensor(sens))
+    if CONF_DEFROST in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_DEFROST])
+        cg.add(var.set_defrost_sensor(sens))

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -23,6 +23,13 @@ static void set_number(number::Number *number, float value) {
     number->publish_state(value);
 }
 
+#ifdef USE_BINARY_SENSOR
+static void set_binary_sensor(binary_sensor::BinarySensor *sens, bool value) {
+  if (sens != nullptr && (!sens->has_state() || sens->state != value))
+    sens->publish_state(value);
+}
+#endif
+
 template<typename T> void update_property(T &property, const T &value, bool &flag) {
   if (property != value) {
     property = value;
@@ -299,6 +306,9 @@ void ClimateMideaXYE::ParseResponse() {
       set_sensor(this->timer_stop_sensor_, CalculateGetTime(qr.timer_stop));
       set_sensor(this->error_flags_sensor_, static_cast<float>(qr.error_flags.value()));
       set_sensor(this->protect_flags_sensor_, static_cast<float>(qr.protect_flags.value()));
+#ifdef USE_BINARY_SENSOR
+      set_binary_sensor(this->defrost_sensor_, (qr.protect_flags.value() & DEFROST_PROTECT_FLAG) != 0);
+#endif
       break;
     }
     case Command::QUERY_EXTENDED: {

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -307,7 +307,7 @@ void ClimateMideaXYE::ParseResponse() {
       set_sensor(this->error_flags_sensor_, static_cast<float>(qr.error_flags.value()));
       set_sensor(this->protect_flags_sensor_, static_cast<float>(qr.protect_flags.value()));
 #ifdef USE_BINARY_SENSOR
-      set_binary_sensor(this->defrost_sensor_, (qr.protect_flags.value() & DEFROST_PROTECT_FLAG) != 0);
+      set_binary_sensor(this->defrost_sensor_, XYEAdapter::is_defrost_active(qr.protect_flags.value()));
 #endif
       break;
     }

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -9,6 +9,9 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
 #include "esphome/core/log.h"
 #include "ir_transmitter.h"
 #include "static_pressure_number.h"
@@ -133,6 +136,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void set_protect_flags_sensor(Sensor *sensor) { this->protect_flags_sensor_ = sensor; }
   void set_humidity_setpoint_sensor(Sensor *sensor) { this->humidity_sensor_ = sensor; }
   void set_power_sensor(Sensor *sensor) { this->power_sensor_ = sensor; }
+#ifdef USE_BINARY_SENSOR
+  void set_defrost_sensor(binary_sensor::BinarySensor *sensor) { this->defrost_sensor_ = sensor; }
+#endif
   void set_follow_me_sensor(Sensor *sensor);
   void set_internal_current_temperature_sensor(Sensor *sensor) { this->internal_current_temperature_sensor_ = sensor; }
   void set_use_fahrenheit(bool yesno) { this->use_fahrenheit_ = yesno; }
@@ -209,6 +215,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   Sensor *protect_flags_sensor_{nullptr};
   Sensor *humidity_sensor_{nullptr};
   Sensor *power_sensor_{nullptr};
+#ifdef USE_BINARY_SENSOR
+  binary_sensor::BinarySensor *defrost_sensor_{nullptr};
+#endif
   Sensor *follow_me_sensor_{nullptr};
   Sensor *internal_current_temperature_sensor_{nullptr};
   StaticPressureNumber *static_pressure_number_{nullptr};

--- a/esphome/components/midea_xye/xye.h
+++ b/esphome/components/midea_xye/xye.h
@@ -306,6 +306,10 @@ enum class SubsystemFlags : uint8_t {
   OK = 0x80                  ///< Subsystem OK, no protection active (bit 7 set)
 };
 
+/// Defrost active flag within the 16-bit `protect_flags` field of the C0 QUERY response.
+/// When set, the indoor unit is currently running a defrost cycle.
+constexpr uint16_t DEFROST_PROTECT_FLAG = 0x0002;
+
 /**
  * @brief Special temperature value for fan mode
  */

--- a/esphome/components/midea_xye/xye_adapter.cpp
+++ b/esphome/components/midea_xye/xye_adapter.cpp
@@ -111,6 +111,10 @@ ModeFlags XYEAdapter::get_mode_flags(climate::ClimatePreset preset,
       ((swing_mode != climate::ClimateSwingMode::CLIMATE_SWING_OFF) * static_cast<uint8_t>(ModeFlags::SWING)));
 }
 
+bool XYEAdapter::is_defrost_active(uint16_t protect_flags) noexcept {
+  return (protect_flags & DEFROST_PROTECT_FLAG) != 0;
+}
+
 }  // namespace xye
 }  // namespace midea
 }  // namespace esphome

--- a/esphome/components/midea_xye/xye_adapter.h
+++ b/esphome/components/midea_xye/xye_adapter.h
@@ -44,6 +44,9 @@ struct XYEAdapter {
   /// Returns the XYE ModeFlags for the given ESPHome preset and swing mode.
   static ModeFlags get_mode_flags(climate::ClimatePreset preset,
                                   climate::ClimateSwingMode swing_mode) noexcept;
+
+  /// Returns true when the defrost bit is set in the C0 QUERY response `protect_flags` value.
+  static bool is_defrost_active(uint16_t protect_flags) noexcept;
 };
 
 }  // namespace xye

--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -42,7 +42,9 @@ climate:
     follow_me_sensor: test_sensor  # Automatically updates follow_me from this sensor
     internal_current_temperature:
       name: "Internal Current Temperature"
-    
+    defrost:
+      name: "Defrost Active"
+
 # Temperature sensor required for follow_me
 sensor:
   - platform: homeassistant

--- a/tests/midea_xye_esp32.yaml
+++ b/tests/midea_xye_esp32.yaml
@@ -44,7 +44,9 @@ climate:
     follow_me_sensor: test_sensor  # Automatically updates follow_me from this sensor
     internal_current_temperature:
       name: "Internal Current Temperature"
-    
+    defrost:
+      name: "Defrost Active"
+
 # Temperature sensor required for follow_me
 sensor:
   - platform: homeassistant


### PR DESCRIPTION
## Summary

Expose the indoor unit defrost-cycle status as an optional `binary_sensor`, decoded from bit 1 of the 16-bit `protect_flags` field in the C0 QUERY response.

- `xye.h`: `constexpr uint16_t DEFROST_PROTECT_FLAG = 0x0002;`
- `climate_midea_xye.{h,cpp}`: new setter, member, and one decode line in `ParseResponse()` QUERY branch, all gated on `USE_BINARY_SENSOR`.
- `climate.py`: `binary_sensor` import, `CONF_DEFROST`, schema, and `to_code` wiring; extends `AUTO_LOAD`.
- YAML compile tests + README example updated.

Closes #97

## Notes

- Implementation is the defrost-only subset of [PR #85](https://github.com/HomeOps/ESPHome-Midea-XYE/pull/85) (ported from mdrobnak's `units_switch` branch). #96 and #98 remain open for the Fahrenheit switch and fan-speed-while-AUTO signal respectively. Design direction for #98 has shifted (attribute, not a separate text_sensor) so this PR intentionally does **not** include that change.
- The bit position `0x0002` comes from the `units_switch` branch. Canonical until someone with a heat-pump on the bus verifies it fires only during an actual defrost cycle. Zero device-side risk either way — this is a read-only decode.
- Uses the diagnostic entity category and the `mdi:snowflake-thermometer` icon to match how defrost is typically surfaced in HA HVAC integrations.

## Test plan

- [ ] `esphome compile tests/midea_xye.yaml` passes.
- [ ] `esphome compile tests/midea_xye_esp32.yaml` passes.
- [ ] Flash a heat-pump; confirm `binary_sensor.defrost_active` appears in HA.
- [ ] Wait for (or force) a defrost cycle; confirm the sensor reads `on` during defrost and returns to `off` when the cycle ends.
- [ ] Regression: confirm the existing `protect_flags` raw sensor still publishes alongside the new binary_sensor.