### PR TITLE
docs: document C0 byte 27-29 observations from cross-hardware captures

### DIFF
--- a/esphome/components/midea_xye/PROTOCOL.md
+++ b/esphome/components/midea_xye/PROTOCOL.md
@@ -94,12 +94,54 @@ Byte    Field               Description
 24      Protect Flags Low   Protection flags (low byte)
 25      Protect Flags High  Protection flags (high byte)
 26      CCM Error Flags     Communication error flags
-27      Unknown4            Unknown/reserved
-28      Unknown5            Unknown/reserved
-29      Unknown6            Unknown/reserved
+27      Unknown4            Unknown. Hardware-dependent (0x00 or 0x14 observed),
+                            steady within a given device.
+28      Unknown5            Unknown. Observed varying over time on some hardware
+                            (see "Byte 27-29 observations" below).
+29      Unknown6            Unknown. Observed varying over time on some hardware
+                            (see "Byte 27-29 observations" below).
 30      CRC                 Checksum
 31      Prologue            Always 0x55
 ```
+
+### Byte 27-29 observations
+
+These three bytes are not yet decoded. Cross-referencing independent captures
+yields the following partial picture:
+
+- **Byte 27 (`Unknown4`)** — hardware-dependent, steady within a given device.
+  `0x00` across 771 C0 responses on a ducted heat pump in the US Pacific
+  Northwest; `0x14` across dozens of C0 responses on a C&H CH-36AHU
+  (Midea-manufactured; Home Assistant community thread
+  ["Midea A/C via Local XYE"](https://community.home-assistant.io/t/midea-a-c-via-local-xye/),
+  mdrobnak). Likely a capability / model-class byte.
+- **Byte 28 (`Unknown5`)** — *not* a static status word and *not* a monotonic
+  counter. A ~22-minute idle capture from a PNW ducted heat pump recorded 7
+  distinct values drifting up *and* down:
+
+  ```
+  0xE0 → 0xD0 → 0xC2 → 0xBE → 0xBA → 0xAE → 0xB0
+  (decimal: 224, 208, 194, 190, 186, 174, 176)
+  ```
+
+  The value can sit on a single setting for many minutes (the `0xE0` run was
+  ~11 minutes in that capture) then step by a few counts. A C&H CH-36AHU
+  capture recorded much more rapid movement through 0x00..0xFF.
+
+  A second PNW capture (109 C0 frames, 3m 43s) deliberately exercised four
+  user-initiated state transitions (OFF → FAN → COOL @ 20°C → COOL @ 22°C)
+  and byte 28 **did not move** — it stayed at `0xE0` through every
+  transition, as did byte 27 (`0x00`) and byte 29 (`0x01`). So byte 28 is
+  **not coupled to `operation_mode` or `target_temperature`** on the
+  user-command timescale. Whatever drives it, HVAC setpoint controls are
+  not an input. Best remaining hypotheses: an internal sensor reading
+  (compressor discharge? evaporator pressure?), a defrost / protection
+  countdown, or some non-user-facing controller state.
+- **Byte 29 (`Unknown6`)** — hardware-dependent steady state: `0x01` across
+  all 771 PNW frames; alternates `0x00`/`0x01` with occasional `0x02` on the
+  C&H unit. Meaning unclear.
+
+Any of these interpretations is provisional until more hardware is captured.
 
 ## Commands
 

--- a/esphome/components/midea_xye/xye_recv.h
+++ b/esphome/components/midea_xye/xye_recv.h
@@ -57,9 +57,18 @@ struct __attribute__((packed)) QueryResponseData {
   Flags16 error_flags;             ///< [22-23] Error flags (16-bit) - E1/E2 error codes
   Flags16 protect_flags;           ///< [24-25] Protection flags (16-bit)
   CcmErrorFlags ccm_communication_error_flags; ///< [26] CCM communication error flags
-  uint8_t unknown4;                ///< [27] Unknown/reserved
-  uint8_t unknown5;                ///< [28] Unknown/reserved
-  uint8_t unknown6;                ///< [29] Unknown/reserved
+  uint8_t unknown4;                ///< [27] Unknown. Hardware-dependent: 0x00 across 771 C0
+                                   ///<      responses on a ducted heat pump, 0x14 on a C&H
+                                   ///<      CH-36AHU. Steady within each device.
+  uint8_t unknown5;                ///< [28] Unknown. Drifts up and down over time, not a simple
+                                   ///<      counter. Ducted heat-pump idle capture showed 7
+                                   ///<      distinct values 0xAE..0xE0, with one setting holding
+                                   ///<      for ~11 min before stepping; C&H CH-36AHU capture
+                                   ///<      showed much more rapid movement across 0x00..0xFF.
+                                   ///<      Not reactive to user mode/setpoint changes.
+  uint8_t unknown6;                ///< [29] Unknown. Hardware-dependent steady state: 0x01
+                                   ///<      across 771 ducted-heat-pump frames; alternates
+                                   ///<      0x00/0x01 (occasional 0x02) on a C&H CH-36AHU.
 
   /**
    * @brief Print debug information for query response data


### PR DESCRIPTION
## Summary

**Revised (v4)** — a live capture with user-initiated state changes adds a negative result.

The initial PR renamed C0 QUERY response bytes 28/29 to `startup_status_low`/`_high`, based on a 116-frame capture from a ducted heat pump in the US Pacific Northwest where the pair read `0xE0 / 0x01` steady. The hypothesis was that the bytes counted up during power-on init and settled at this "ready" value.

Three independent captures refute that:

### PNW ducted heat pump — idle, 22 min, 771 C0 responses

Byte 28 takes 7 distinct values drifting up *and* down:

```
0xE0 → 0xD0 → 0xC2 → 0xBE → 0xBA → 0xAE → 0xB0
(decimal: 224, 208, 194, 190, 186, 174, 176)
```

The `0xE0` run lasted ~11 minutes before stepping. Byte 27 = `0x00`, byte 29 = `0x01` across all 771 frames.

### PNW ducted heat pump — active, 3m 43s, 109 C0 responses

Four deliberate user-initiated state transitions during the capture:

| Time | `operation_mode` | `target_temperature` | U4 | **U5** | U6 |
|------|------------------|----------------------|------|--------|------|
| 20:48:11 | OFF | 22.0°C | 0x00 | **0xE0** | 0x01 |
| 20:49:34 | FAN | 24.0°C | 0x00 | **0xE0** | 0x01 |
| 20:50:08 | COOL | 20.0°C | 0x00 | **0xE0** | 0x01 |
| 20:50:26 | COOL | 22.0°C | 0x00 | **0xE0** | 0x01 |

Bytes 27/28/29 did **not** move across any of the four transitions. **Byte 28 is not coupled to `operation_mode` or `target_temperature`** on the user-command timescale.

### C&H CH-36AHU — Home Assistant community thread, [mdrobnak](https://community.home-assistant.io/t/midea-a-c-via-local-xye/)

Byte 28 moves rapidly across 0x00..0xFF during startup + steady-state. Byte 27 = `0x14` steady. Byte 29 alternates `0x00/0x01` with occasional `0x02`.

### Cross-hardware summary

| | PNW ducted | C&H CH-36AHU |
|---|---|---|
| byte 27 | `0x00` × 771 | `0x14` steady |
| byte 29 | `0x01` × 771 | alternates 00/01 (occasional 02) |
| byte 28 | 7 values, slow drift | rapid movement 0x00..0xFF |

Byte 27 is hardware-dependent (likely a capability / model-class byte). Byte 29's behavior is also hardware-dependent. Byte 28 has no known driver — not user commands, not a counter, not a startup marker.

## What this PR now does

Documentation only. No code or symbol changes.

* **Reverts** the field rename (`unknown5`/`unknown6` stay) and the `STARTUP_STATUS_*_READY` constants.
* **Adds** a new `PROTOCOL.md` subsection "Byte 27-29 observations" with the cross-hardware data and the user-command-invariance result.
* **Expands** doc comments on `QueryResponseData::unknown4..6` in `xye_recv.h`.

## Why keep the names as `unknownN`

Naming byte 28 now would lock in a premature interpretation — same mistake as v1. We don't know what drives it, only what doesn't (user commands). Better to document observations and wait.

## Test plan

- [x] No code symbols added, removed, or renamed.
- [x] `grep` confirms no remaining references to `startup_status_*` / `STARTUP_STATUS_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)