### PR TITLE
Some Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ climate:
       name: Protect Flags
     defrost:                    # Optional. True while the indoor unit is running a defrost cycle
       name: Defrost Active
+    compressor_active:          # Optional. True while the compressor is actively running
+      name: Compressor Active
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ climate:
                                         # The sensor is updated on state change and every 30 seconds
     outdoor_temperature:        # Optional. Outdoor temperature sensor
       name: Outside Temp
+    temperature_1:             # Optional. Internal/inlet air temperature (T1) - room temperature as read by the unit
+      name: T1 Internal Air Temp
+    fan_speed:                  # Optional. Current physical fan speed reported by the unit (raw nibble: 0=off, 1=high, 2=med, 3/4=low)
+      name: Fan Speed
     temperature_2a:             # Optional. Inside coil temperature
       name: Inside Coil Inlet Temp
     temperature_2b:             # Optional. Inside coil temperature

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ climate:
       name: Outside Temp
     temperature_1:             # Optional. Internal/inlet air temperature (T1) - room temperature as read by the unit
       name: T1 Internal Air Temp
-    fan_speed:                  # Optional. Current physical fan speed reported by the unit (raw nibble: 0=off, 1=high, 2=med, 3/4=low)
+    fan_speed:                  # Optional. Current physical fan speed reported by the unit as text (off, high, medium, low; protocol nibble mapping: 0=off, 1=high, 2=medium, 3/4=low)
       name: Fan Speed
     temperature_2a:             # Optional. Inside coil temperature
       name: Inside Coil Inlet Temp

--- a/esphome/components/midea_xye/PROTOCOL.md
+++ b/esphome/components/midea_xye/PROTOCOL.md
@@ -86,7 +86,7 @@ Byte    Field               Description
 16      Unknown2            Unknown/reserved
 17      Timer Start         Start timer setting
 18      Timer Stop          Stop timer setting
-19      Unknown3            Unknown/reserved
+19      Compressor Status   Bit 0 (0x01) = compressor active/running; 0x00 = compressor idle
 20      Mode Flags          Special mode flags
 21      Operation Flags     Status flags (water pump, water lock, etc.)
 22      Error Flags Low     Error code/flags (low byte)

--- a/esphome/components/midea_xye/README.md
+++ b/esphome/components/midea_xye/README.md
@@ -91,6 +91,10 @@ climate:
       name: Error Flags
     protect_flags:              # Optional. 
       name: Protect Flags
+    defrost:                    # Optional. True while the indoor unit is running a defrost cycle
+      name: Defrost Active
+    compressor_active:          # Optional. True while the compressor is actively running
+      name: Compressor Active
 
 ```
 

--- a/esphome/components/midea_xye/README.md
+++ b/esphome/components/midea_xye/README.md
@@ -71,6 +71,10 @@ climate:
       - VERTICAL
     outdoor_temperature:        # Optional. Outdoor temperature sensor
       name: Outside Temp
+    temperature_1:             # Optional. Internal/inlet air temperature (T1)
+      name: Internal/Inlet Air Temp
+    fan_speed:                 # Optional. Current physical fan speed (raw nibble: 0=off, 1=high, 2=med, 3/4=low)
+      name: Fan Speed
     temperature_2a:             # Optional. Inside coil temperature
       name: Inside Coil Inlet Temp
     temperature_2b:             # Optional. Inside coil temperature

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -67,6 +67,7 @@ CONF_STATIC_PRESSURE = "static_pressure"
 CONF_FOLLOW_ME_SENSOR = "follow_me_sensor"
 CONF_INTERNAL_CURRENT_TEMPERATURE = "internal_current_temperature"
 CONF_DEFROST = "defrost"
+CONF_COMPRESSOR_ACTIVE = "compressor_active"
 midea_xye_ns = cg.esphome_ns.namespace("midea").namespace("xye")
 ClimateMideaXYE = midea_xye_ns.class_("ClimateMideaXYE", climate.Climate, cg.Component)
 StaticPressureNumber = midea_xye_ns.class_("StaticPressureNumber", number.Number, cg.Component)
@@ -262,6 +263,10 @@ CONFIG_SCHEMA = cv.All(
                 icon="mdi:snowflake-thermometer",
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_COMPRESSOR_ACTIVE): binary_sensor.binary_sensor_schema(
+                icon="mdi:engine",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -452,3 +457,6 @@ async def to_code(config):
     if CONF_DEFROST in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_DEFROST])
         cg.add(var.set_defrost_sensor(sens))
+    if CONF_COMPRESSOR_ACTIVE in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_COMPRESSOR_ACTIVE])
+        cg.add(var.set_compressor_active_sensor(sens))

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -1,6 +1,6 @@
 from esphome.core import coroutine
 from esphome import automation
-from esphome.components import binary_sensor, climate, sensor, uart, remote_transmitter, number
+from esphome.components import binary_sensor, climate, sensor, text_sensor, uart, remote_transmitter, number
 from esphome.components.remote_base import CONF_TRANSMITTER_ID
 import esphome.config_validation as cv
 import esphome.codegen as cg
@@ -49,8 +49,10 @@ from esphome.components.climate import (
 
 #CODEOWNERS = ["@dudanov"]
 DEPENDENCIES = ["climate", "uart", "wifi"]
-AUTO_LOAD = ["binary_sensor", "number", "sensor"]
+AUTO_LOAD = ["binary_sensor", "number", "sensor", "text_sensor"]
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
+CONF_TEMPERATURE_1 = "temperature_1"
+CONF_FAN_SPEED = "fan_speed"
 CONF_TEMPERATURE_2A = "temperature_2a"
 CONF_TEMPERATURE_2B = "temperature_2b"
 CONF_TEMPERATURE_3 = "temperature_3"
@@ -165,6 +167,17 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_FAN_SPEED): text_sensor.text_sensor_schema(
+                icon="mdi:fan",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
@@ -394,6 +407,12 @@ async def to_code(config):
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temperature_sensor(sens))
+    if CONF_TEMPERATURE_1 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE_1])
+        cg.add(var.set_temperature_1_sensor(sens))
+    if CONF_FAN_SPEED in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_FAN_SPEED])
+        cg.add(var.set_fan_speed_sensor(sens))
     if CONF_TEMPERATURE_2A in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_2A])
         cg.add(var.set_temperature_2a_sensor(sens))

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -283,7 +283,9 @@ void ClimateMideaXYE::ParseResponse() {
 #endif
 
         update_property(this->action,
-                        XYEAdapter::get_climate_action(mode, qr.fan_mode, qr.operation_mode),
+                        XYEAdapter::get_climate_action(mode, qr.fan_mode, qr.operation_mode,
+                                                       (qr.compressor_status & C0_COMPRESSOR_ACTIVE_FLAG) != 0,
+                                                       XYEAdapter::is_defrost_active(qr.protect_flags.value())),
                         need_publish);
 
         if ((this->swing_mode != ClimateSwingMode::CLIMATE_SWING_OFF) !=
@@ -323,6 +325,8 @@ void ClimateMideaXYE::ParseResponse() {
       set_sensor(this->protect_flags_sensor_, static_cast<float>(qr.protect_flags.value()));
 #ifdef USE_BINARY_SENSOR
       set_binary_sensor(this->defrost_sensor_, XYEAdapter::is_defrost_active(qr.protect_flags.value()));
+      set_binary_sensor(this->compressor_active_sensor_,
+                        (qr.compressor_status & C0_COMPRESSOR_ACTIVE_FLAG) != 0);
 #endif
       break;
     }

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -18,6 +18,11 @@ static void set_sensor(Sensor *sensor, float value) {
     sensor->publish_state(value);
 }
 
+static void set_text_sensor(text_sensor::TextSensor *sensor, const char *value) {
+  if (sensor != nullptr && (!sensor->has_state() || sensor->state != value))
+    sensor->publish_state(value);
+}
+
 static void set_number(number::Number *number, float value) {
   if (number != nullptr && (!number->has_state() || number->state != value))
     number->publish_state(value);
@@ -265,6 +270,7 @@ void ClimateMideaXYE::ParseResponse() {
 
         // Publish the internal temperature to the sensor if configured
         set_sensor(this->internal_current_temperature_sensor_, this->internal_temperature_);
+        set_sensor(this->temperature_1_sensor_, this->internal_temperature_);
 
         // Update current_temperature based on sensor availability
         this->update_current_temperature_from_sensors_(need_publish);
@@ -298,6 +304,15 @@ void ClimateMideaXYE::ParseResponse() {
       if (need_publish)
         this->publish_state();
 
+      {
+        const uint8_t spd = static_cast<uint8_t>(qr.fan_mode) & FAN_SPEED_MASK;
+        const char *spd_str = (spd == static_cast<uint8_t>(FanMode::FAN_HIGH))    ? "high"
+                            : (spd == static_cast<uint8_t>(FanMode::FAN_MEDIUM))  ? "medium"
+                            : (spd == static_cast<uint8_t>(FanMode::FAN_LOW) ||
+                               spd == static_cast<uint8_t>(FanMode::FAN_LOW_ALT)) ? "low"
+                                                                                   : "off";
+        set_text_sensor(this->fan_speed_sensor_, spd_str);
+      }
       set_sensor(this->temperature_2a_sensor_, XYEAdapter::get_temperature(qr.t2a_temperature.value));
       set_sensor(this->temperature_2b_sensor_, XYEAdapter::get_temperature(qr.t2b_temperature.value));
       set_sensor(this->temperature_3_sensor_, XYEAdapter::get_temperature(qr.t3_temperature.value));

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -6,6 +6,7 @@
 #include "esphome/components/climate/climate_traits.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -126,6 +127,8 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
 
   void dump_config() override;
   void set_outdoor_temperature_sensor(Sensor *sensor) { this->outdoor_sensor_ = sensor; }
+  void set_temperature_1_sensor(Sensor *sensor) { this->temperature_1_sensor_ = sensor; }
+  void set_fan_speed_sensor(text_sensor::TextSensor *sensor) { this->fan_speed_sensor_ = sensor; }
   void set_temperature_2a_sensor(Sensor *sensor) { this->temperature_2a_sensor_ = sensor; }
   void set_temperature_2b_sensor(Sensor *sensor) { this->temperature_2b_sensor_ = sensor; }
   void set_temperature_3_sensor(Sensor *sensor) { this->temperature_3_sensor_ = sensor; }
@@ -205,6 +208,8 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   std::vector<const char *> supported_custom_fan_modes_{};
   bool use_fahrenheit_;
   Sensor *outdoor_sensor_{nullptr};
+  Sensor *temperature_1_sensor_{nullptr};
+  text_sensor::TextSensor *fan_speed_sensor_{nullptr};
   Sensor *temperature_2a_sensor_{nullptr};
   Sensor *temperature_2b_sensor_{nullptr};
   Sensor *temperature_3_sensor_{nullptr};

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -141,6 +141,7 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void set_power_sensor(Sensor *sensor) { this->power_sensor_ = sensor; }
 #ifdef USE_BINARY_SENSOR
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) { this->defrost_sensor_ = sensor; }
+  void set_compressor_active_sensor(binary_sensor::BinarySensor *sensor) { this->compressor_active_sensor_ = sensor; }
 #endif
   void set_follow_me_sensor(Sensor *sensor);
   void set_internal_current_temperature_sensor(Sensor *sensor) { this->internal_current_temperature_sensor_ = sensor; }
@@ -222,6 +223,7 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   Sensor *power_sensor_{nullptr};
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *defrost_sensor_{nullptr};
+  binary_sensor::BinarySensor *compressor_active_sensor_{nullptr};
 #endif
   Sensor *follow_me_sensor_{nullptr};
   Sensor *internal_current_temperature_sensor_{nullptr};

--- a/esphome/components/midea_xye/xye.h
+++ b/esphome/components/midea_xye/xye.h
@@ -122,6 +122,13 @@ constexpr uint8_t FAN_AUTO_FLAG = 0x80;
 constexpr uint8_t FAN_SPEED_MASK = 0x0F;
 
 /**
+ * @brief Compressor active/running flag in C0 response byte [19].
+ * Bit 0 is set while the compressor is actively running; clear when the compressor
+ * is idle (fan may still be running for circulation or residual airflow).
+ */
+constexpr uint8_t C0_COMPRESSOR_ACTIVE_FLAG = 0x01;
+
+/**
  * @brief Flags for special operation modes
  */
 enum class ModeFlags : uint8_t {

--- a/esphome/components/midea_xye/xye_adapter.cpp
+++ b/esphome/components/midea_xye/xye_adapter.cpp
@@ -50,25 +50,33 @@ float XYEAdapter::get_target_temperature(uint8_t raw) noexcept {
 }
 
 climate::ClimateAction XYEAdapter::get_climate_action(climate::ClimateMode mode, FanMode fan_mode,
-                                                       OperationMode op_mode) noexcept {
+                                                       OperationMode op_mode, bool compressor_active,
+                                                       bool defrost_active) noexcept {
+  // During defrost the unit is temporarily reversing the refrigeration cycle to
+  // melt ice on the outdoor coil — it is not delivering heat to the room.
+  if (defrost_active && mode == ClimateMode::CLIMATE_MODE_HEAT)
+    return ClimateAction::CLIMATE_ACTION_IDLE;
+
   const bool fan_running = (static_cast<uint8_t>(fan_mode) & FAN_SPEED_MASK) != 0x00;
 
   ClimateAction action = ClimateAction::CLIMATE_ACTION_IDLE;
   if (mode == ClimateMode::CLIMATE_MODE_HEAT && fan_running) {
-    action = ClimateAction::CLIMATE_ACTION_HEATING;
+    // Report HEATING only when the compressor is actually running; otherwise the fan
+    // is circulating air without active heating (e.g. compressor protection delay).
+    action = compressor_active ? ClimateAction::CLIMATE_ACTION_HEATING : ClimateAction::CLIMATE_ACTION_FAN;
   } else if (mode == ClimateMode::CLIMATE_MODE_COOL && fan_running) {
-    action = ClimateAction::CLIMATE_ACTION_COOLING;
+    action = compressor_active ? ClimateAction::CLIMATE_ACTION_COOLING : ClimateAction::CLIMATE_ACTION_FAN;
   }
 
   // In heat/cool (auto) mode refine the action using the unit's reported sub-mode.
   if (mode == ClimateMode::CLIMATE_MODE_HEAT_COOL) {
     const uint8_t op_raw = static_cast<uint8_t>(op_mode) & OP_MODE_VALUE_MASK;
     if (op_raw == static_cast<uint8_t>(OperationMode::COOL))
-      action = ClimateAction::CLIMATE_ACTION_COOLING;
+      action = compressor_active ? ClimateAction::CLIMATE_ACTION_COOLING : ClimateAction::CLIMATE_ACTION_FAN;
     else if (op_raw == static_cast<uint8_t>(OperationMode::FAN))
       action = ClimateAction::CLIMATE_ACTION_FAN;
     else if (op_raw == static_cast<uint8_t>(OperationMode::HEAT))
-      action = ClimateAction::CLIMATE_ACTION_HEATING;
+      action = compressor_active ? ClimateAction::CLIMATE_ACTION_HEATING : ClimateAction::CLIMATE_ACTION_FAN;
   }
 
   return action;

--- a/esphome/components/midea_xye/xye_adapter.h
+++ b/esphome/components/midea_xye/xye_adapter.h
@@ -26,10 +26,13 @@ struct XYEAdapter {
   /// masking out the SET_TEMP_STATUS_FLAG (bit 6) that the unit may set in certain states.
   static float get_target_temperature(uint8_t raw) noexcept;
 
-  /// Returns the ClimateAction derived from the current mode, fan, and operation state.
+  /// Returns the ClimateAction derived from the current mode, fan, operation state, and compressor status.
+  /// @param compressor_active true when the compressor is actively running (C0 byte [19] bit 0 set).
+  /// @param defrost_active true when the unit is in a defrost cycle; forces IDLE in heating mode.
   /// @note Intended for use when mode != CLIMATE_MODE_OFF.
   static climate::ClimateAction get_climate_action(climate::ClimateMode mode, FanMode fan_mode,
-                                                   OperationMode op_mode) noexcept;
+                                                   OperationMode op_mode, bool compressor_active,
+                                                   bool defrost_active) noexcept;
 
   /// Returns the XYE OperationMode for the given ESPHome ClimateMode.
   static OperationMode get_operation_mode(climate::ClimateMode mode) noexcept;

--- a/esphome/components/midea_xye/xye_recv.cpp
+++ b/esphome/components/midea_xye/xye_recv.cpp
@@ -24,7 +24,7 @@ size_t QueryResponseData::print_debug(const char *tag, size_t left, int level) c
   left = print_debug_uint8(tag, "unknown2", unknown2, left, level);
   left = print_debug_uint8(tag, "timer_start", timer_start, left, level);
   left = print_debug_uint8(tag, "timer_stop", timer_stop, left, level);
-  left = print_debug_uint8(tag, "unknown3", unknown3, left, level);
+  left = print_debug_uint8(tag, "compressor_status", compressor_status, left, level);
   left = print_debug_enum(tag, "mode_flags", mode_flags, left, level);
   left = print_debug_enum(tag, "operation_flags", operation_flags, left, level);
   left = error_flags.print_debug(tag, "error_flags", left, level);

--- a/esphome/components/midea_xye/xye_recv.h
+++ b/esphome/components/midea_xye/xye_recv.h
@@ -51,7 +51,7 @@ struct __attribute__((packed)) QueryResponseData {
   uint8_t unknown2;                ///< [16] Unknown/reserved
   uint8_t timer_start;             ///< [17] Start timer setting (combinable TimerFlags)
   uint8_t timer_stop;              ///< [18] Stop timer setting (combinable TimerFlags)
-  uint8_t unknown3;                ///< [19] Unknown/reserved
+  uint8_t compressor_status;       ///< [19] Compressor status: bit 0 = compressor active/running (C0_COMPRESSOR_ACTIVE_FLAG)
   ModeFlags mode_flags;            ///< [20] Mode flags (ECO, AUX_HEAT, SWING, etc.)
   OperationFlags operation_flags;  ///< [21] Operation status flags (water pump, water lock)
   Flags16 error_flags;             ///< [22-23] Error flags (16-bit) - E1/E2 error codes

--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -48,6 +48,8 @@ climate:
       name: "Fan Speed"
     defrost:
       name: "Defrost Active"
+    compressor_active:
+      name: "Compressor Active"
 
 # Temperature sensor required for follow_me
 sensor:

--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -42,6 +42,10 @@ climate:
     follow_me_sensor: test_sensor  # Automatically updates follow_me from this sensor
     internal_current_temperature:
       name: "Internal Current Temperature"
+    temperature_1:
+      name: "T1 Internal/Inlet Air Temperature"
+    fan_speed:
+      name: "Fan Speed"
     defrost:
       name: "Defrost Active"
 


### PR DESCRIPTION
Breaking out T1 and fan speed as optional sensors that can easily be used for automations.

Introduce C0 byte 19 as the compressor_running bit.

Change the climate entity action, so it uses the new compressor_running bit to declare Heating or Cooling actions. Old algorithm assumed if the fan was on, that the unit was heating or cooling, but that's not strictly true. Systems can be configured to circulate air between running heating/cooling cycles.