### PR TITLE
feat: sync HA fan mode from C4 target_fan_speed when sync_fan_mode_fr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,18 @@ climate:
       name: Error Flags
     protect_flags:              # Optional
       name: Protect Flags
+    fan_speed:                  # Optional. Physical fan speed (0=off, 1=low, 2=medium, 3=high)
+      name: Fan Speed
     defrost:                    # Optional. True while the indoor unit is running a defrost cycle
       name: Defrost Active
+    compressor_active:          # Optional. True while the compressor is running
+      name: Compressor Active
+    compressor_aware_action: false  # Optional. Opt-in: derive heating/cooling/idle action
+                                    # from the compressor + defrost state. Default false
+                                    # (legacy: fan running implies heating/cooling).
+    sync_fan_mode_from_device: false  # Optional. Opt-in: update the HA fan mode from the
+                                      # physical thermostat's commanded speed (C4 packet).
+                                      # Default false (HA fan mode only changes on HA commands).
 ```
 
 ## Debugging

--- a/esphome/components/midea_xye/README.md
+++ b/esphome/components/midea_xye/README.md
@@ -96,6 +96,9 @@ climate:
     compressor_aware_action: false  # Optional. Opt-in: derive heating/cooling/idle action
                                     # from the compressor + defrost state. Default false
                                     # (legacy: fan running implies heating/cooling).
+    sync_fan_mode_from_device: false  # Optional. Opt-in: update the HA fan mode from the
+                                      # physical thermostat's commanded speed (C4 packet).
+                                      # Default false (HA fan mode only changes on HA commands).
 
 ```
 

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -68,6 +68,7 @@ CONF_DEFROST = "defrost"
 CONF_COMPRESSOR_ACTIVE = "compressor_active"
 CONF_FAN_SPEED = "fan_speed"
 CONF_COMPRESSOR_AWARE_ACTION = "compressor_aware_action"
+CONF_SYNC_FAN_MODE_FROM_DEVICE = "sync_fan_mode_from_device"
 midea_xye_ns = cg.esphome_ns.namespace("midea").namespace("xye")
 ClimateMideaXYE = midea_xye_ns.class_("ClimateMideaXYE", climate.Climate, cg.Component)
 StaticPressureNumber = midea_xye_ns.class_("StaticPressureNumber", number.Number, cg.Component)
@@ -145,6 +146,10 @@ CONFIG_SCHEMA = cv.All(
             # and the defrost state. Off by default while byte 19 is still provisional;
             # legacy "fan running implies heating/cooling" behaviour is used when false.
             cv.Optional(CONF_COMPRESSOR_AWARE_ACTION, default=False): cv.boolean,
+            # Opt-in: sync this->fan_mode from C4 target_fan_speed (commanded speed from the
+            # physical thermostat), so Home Assistant reflects fan mode changes even when
+            # not triggered by an HA command.
+            cv.Optional(CONF_SYNC_FAN_MODE_FROM_DEVICE, default=False): cv.boolean,
             cv.OnlyWith(CONF_TRANSMITTER_ID, "remote_transmitter"): cv.use_id(
                 remote_transmitter.RemoteTransmitterComponent
             ),
@@ -389,6 +394,7 @@ async def to_code(config):
     cg.add(var.set_response_timeout(config[CONF_TIMEOUT].total_milliseconds))
     cg.add(var.set_use_fahrenheit(config[CONF_USE_FAHRENHEIT]))
     cg.add(var.set_compressor_aware_action(config[CONF_COMPRESSOR_AWARE_ACTION]))
+    cg.add(var.set_sync_fan_mode_from_device(config[CONF_SYNC_FAN_MODE_FROM_DEVICE]))
     if CONF_TRANSMITTER_ID in config:
         cg.add_define("USE_REMOTE_TRANSMITTER")
         transmitter_ = await cg.get_variable(config[CONF_TRANSMITTER_ID])

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -350,7 +350,9 @@ void ClimateMideaXYE::ParseResponse() {
       // Sync fan mode from the C4 target_fan_speed field when enabled. This is the commanded
       // speed as set on the physical thermostat and persists when the fan is idle, unlike
       // C0 fan_mode which reads 0x00 when stopped.
-      if (this->sync_fan_mode_from_device_) {
+      // Respect post_set_grace_: if a SET was just issued the device may not yet have
+      // updated its reported target_fan_speed, so skip until C0 has cleared the grace window.
+      if (this->sync_fan_mode_from_device_ && post_set_grace_ == 0) {
         bool fan_need_publish = false;
         const ClimateFanMode new_fan_mode = XYEAdapter::get_climate_fan_mode(exr.target_fan_speed);
         if (!this->fan_mode.has_value() || this->fan_mode.value() != new_fan_mode) {

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -347,6 +347,19 @@ void ClimateMideaXYE::ParseResponse() {
           this->publish_state();
       }
 #endif
+      // Sync fan mode from the C4 target_fan_speed field when enabled. This is the commanded
+      // speed as set on the physical thermostat and persists when the fan is idle, unlike
+      // C0 fan_mode which reads 0x00 when stopped.
+      if (this->sync_fan_mode_from_device_) {
+        bool fan_need_publish = false;
+        const ClimateFanMode new_fan_mode = XYEAdapter::get_climate_fan_mode(exr.target_fan_speed);
+        if (!this->fan_mode.has_value() || this->fan_mode.value() != new_fan_mode) {
+          this->fan_mode = new_fan_mode;
+          fan_need_publish = true;
+        }
+        if (fan_need_publish)
+          this->publish_state();
+      }
       // Note: Previous versions validated fixed protocol marker bytes (0xBC, 0xD6, 0x80, 0x80, 0x80, 0x80)
       // but investigation shows these bytes are actually dynamic engineering values:
       // - Bytes 19-20 (0xBCD6): 16-bit compressor frequency or outdoor fan RPM

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -151,6 +151,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void set_internal_current_temperature_sensor(Sensor *sensor) { this->internal_current_temperature_sensor_ = sensor; }
   void set_use_fahrenheit(bool yesno) { this->use_fahrenheit_ = yesno; }
   void set_compressor_aware_action(bool yesno) { this->compressor_aware_action_ = yesno; }
+  /// Opt-in: when true, this->fan_mode is updated from C4 target_fan_speed on every extended
+  /// query cycle, reflecting the fan setting on the physical thermostat in Home Assistant.
+  void set_sync_fan_mode_from_device(bool yesno) { this->sync_fan_mode_from_device_ = yesno; }
   void set_static_pressure_number(StaticPressureNumber *number) {
     this->static_pressure_number_ = number;
     number->set_parent(this);
@@ -216,6 +219,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   // Opt-in (compressor_aware_action YAML option): when false, get_climate_action is
   // fed compressor_active=true / defrost_active=false to reproduce legacy behaviour.
   bool compressor_aware_action_{false};
+  // Opt-in (sync_fan_mode_from_device YAML option): when true, fan_mode is updated from C4
+  // target_fan_speed (the commanded speed from the physical thermostat).
+  bool sync_fan_mode_from_device_{false};
   Sensor *outdoor_sensor_{nullptr};
   Sensor *fan_speed_sensor_{nullptr};
   Sensor *temperature_2a_sensor_{nullptr};

--- a/esphome/components/midea_xye/xye_adapter.cpp
+++ b/esphome/components/midea_xye/xye_adapter.cpp
@@ -43,6 +43,17 @@ climate::ClimateFanMode XYEAdapter::get_climate_fan_mode(FanMode fan_mode) noexc
   }
 }
 
+climate::ClimateFanMode XYEAdapter::get_climate_fan_mode(TargetFanSpeed target) noexcept {
+  switch (target) {
+    case TargetFanSpeed::FAN_HIGH:   return ClimateFanMode::CLIMATE_FAN_HIGH;
+    case TargetFanSpeed::FAN_MEDIUM: return ClimateFanMode::CLIMATE_FAN_MEDIUM;
+    case TargetFanSpeed::FAN_LOW_ALT:
+    case TargetFanSpeed::FAN_LOW:    return ClimateFanMode::CLIMATE_FAN_LOW;
+    case TargetFanSpeed::FAN_AUTO:
+    default:                         return ClimateFanMode::CLIMATE_FAN_AUTO;
+  }
+}
+
 FanSpeedLevel XYEAdapter::get_fan_speed_level(FanMode fan_mode) noexcept {
   switch (static_cast<uint8_t>(fan_mode) & FAN_SPEED_MASK) {
     case static_cast<uint8_t>(FanMode::FAN_HIGH):    return FanSpeedLevel::SPEED_HIGH;

--- a/esphome/components/midea_xye/xye_adapter.h
+++ b/esphome/components/midea_xye/xye_adapter.h
@@ -35,6 +35,11 @@ struct XYEAdapter {
   /// Returns the ESPHome ClimateFanMode for the given XYE FanMode byte.
   static climate::ClimateFanMode get_climate_fan_mode(FanMode fan_mode) noexcept;
 
+  /// Returns the ESPHome ClimateFanMode for the given XYE TargetFanSpeed value.
+  /// TargetFanSpeed is the commanded speed from the physical thermostat (C4 packet),
+  /// which persists even when the fan is idle — unlike FanMode in C0 which reads 0x00 when stopped.
+  static climate::ClimateFanMode get_climate_fan_mode(TargetFanSpeed target) noexcept;
+
   /// Returns the monotonic FanSpeedLevel ordinal for the given XYE FanMode byte.
   /// The raw protocol nibble is not ordered by speed; this remaps it for the fan_speed sensor.
   static FanSpeedLevel get_fan_speed_level(FanMode fan_mode) noexcept;


### PR DESCRIPTION

## Summary

Adds an opt-in boolean config option `sync_fan_mode_from_device` (default: `false`) that keeps the Home Assistant climate entity's fan mode in sync with the fan speed commanded on the physical thermostat, even when Home Assistant never sent the command.

## Problem

When a Midea proprietary thermostat is on the same XYE bus, fan mode changes made on that thermostat are invisible to Home Assistant. `this->fan_mode` is only updated when HA sends a `control()` call, so HA perpetually shows whatever fan mode it last set — usually `AUTO` from boot — regardless of what the thermostat has selected.

## Why C4, not C0

The C0 response (byte 9) carries the *actual running* fan speed: it reads `0x00` when the fan is idle, making it impossible to distinguish "user set LOW, fan is currently stopped" from "user set AUTO". The C4 extended response (byte 17, `target_fan_speed`) carries the *commanded* speed from the thermostat and persists across idle periods, making it the correct field for tracking user intent.

## Changes

- **`xye_adapter`** — new `get_climate_fan_mode(TargetFanSpeed)` overload; simple switch on discrete enum values (no bit-masking needed unlike the C0 `FanMode` path)
- **climate_midea_xye.h** — `set_sync_fan_mode_from_device(bool)` setter + `sync_fan_mode_from_device_{false}` member
- **climate_midea_xye.cpp** — guarded block in the `QUERY_EXTENDED` handler that decodes `target_fan_speed` and calls `publish_state()` only when the value has changed
- **climate.py** — `sync_fan_mode_from_device` Optional boolean schema entry (default `false`) and `to_code` wiring
- **READMEs** — both root and component README updated with `sync_fan_mode_from_device` plus the previously undocumented `fan_speed`, `compressor_active`, and `compressor_aware_action` options

## Usage

```yaml
climate:
  - platform: midea_xye
    name: Heatpump
    sync_fan_mode_from_device: true   # opt-in; default false
```

## Backward compatibility

Default is `false` — no change in behavior for existing configurations.

---

Want anything adjusted before opening the PR?