### PR TITLE
test: cover sync_fan_mode_from_device opt-in in ESP8266 build

### DIFF
--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -49,6 +49,7 @@ climate:
     compressor_active:
       name: "Compressor Active"
     compressor_aware_action: true
+    sync_fan_mode_from_device: true
 
 # Temperature sensor required for follow_me
 sensor:


### PR DESCRIPTION
## Summary
- Enable `sync_fan_mode_from_device: true` in `tests/midea_xye.yaml` so CI compiles the code path introduced in 0.2.6 (PR #124).

## Why
The opt-in flag `sync_fan_mode_from_device` (default `false`) was added in 0.2.6 to sync `this->fan_mode` from the C4 `target_fan_speed` nibble. Until this PR, no test config set it to `true`, so the gated code was never compile-tested in CI.

The companion opt-in `compressor_aware_action` is already enabled in this same test config, so this keeps the ESP8266 build as the "feature-rich" target while the ESP32 test stays minimal.

## Test plan
- [ ] CI: `esphome compile tests/midea_xye.yaml` succeeds with the flag enabled
- [ ] CI: ESP32 build and native tests remain unaffected