### PR TITLE
fix: greedy \x hex escape in setpoint debug log + CI lint to catch similar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,35 @@ jobs:
 
       - name: Build and run adapter unit tests
         run: |
-          g++ -std=c++17 -Wall -DUSE_ARDUINO \
+          g++ -std=c++17 -Wall -Werror -DUSE_ARDUINO \
             -Itests/native/stubs -Iesphome/components/midea_xye \
             tests/native/test_get_climate_action.cpp \
             esphome/components/midea_xye/xye_adapter.cpp \
             -o "${RUNNER_TEMP}/xye_native_tests"
           "${RUNNER_TEMP}/xye_native_tests"
 
-          g++ -std=c++17 -Wall -DUSE_ARDUINO \
+          g++ -std=c++17 -Wall -Werror -DUSE_ARDUINO \
             -Itests/native/stubs -Iesphome/components/midea_xye \
             tests/native/test_get_target_temperature.cpp \
             esphome/components/midea_xye/xye_adapter.cpp \
             -o "${RUNNER_TEMP}/xye_temp_tests"
           "${RUNNER_TEMP}/xye_temp_tests"
+
+      - name: Lint component sources for warnings
+        # Syntax-only check (-fsyntax-only) against the minimal native stubs.
+        # Catches lexer/parser/semantic warnings (e.g. greedy \x hex escapes)
+        # on sources the unit tests don't link against. -Werror promotes any
+        # warning to a build failure. Sources requiring deeper ESPHome surface
+        # area (climate_midea_xye.cpp) are intentionally excluded — extend the
+        # list as additional stubs are added.
+        run: |
+          for src in \
+            esphome/components/midea_xye/xye.cpp \
+            esphome/components/midea_xye/xye_recv.cpp \
+            esphome/components/midea_xye/xye_send.cpp \
+            esphome/components/midea_xye/xye_adapter.cpp; do
+            echo "Checking $src"
+            g++ -std=c++17 -Wall -Werror -DUSE_ARDUINO -fsyntax-only \
+              -Itests/native/stubs -Iesphome/components/midea_xye \
+              "$src"
+          done

--- a/esphome/components/midea_xye/xye_recv.cpp
+++ b/esphome/components/midea_xye/xye_recv.cpp
@@ -45,10 +45,10 @@ static size_t print_setpoint_debug(const char *tag, const char *name, uint8_t ra
   const float celsius = XYEAdapter::get_target_temperature(raw, use_fahrenheit);
   if (use_fahrenheit) {
     const int fahrenheit = static_cast<int>(raw) - static_cast<int>(FAHRENHEIT_TEMP_OFFSET);
-    ::esphome::esp_log_printf_(level, tag, __LINE__, ESPHOME_LOG_FORMAT("    %s: 0x%02X (%d\xc2\xb0F / %.2f\xc2\xb0C)"),
+    ::esphome::esp_log_printf_(level, tag, __LINE__, ESPHOME_LOG_FORMAT("    %s: 0x%02X (%d°F / %.2f°C)"),
              name, raw, fahrenheit, celsius);
   } else {
-    ::esphome::esp_log_printf_(level, tag, __LINE__, ESPHOME_LOG_FORMAT("    %s: 0x%02X (%.2f\xc2\xb0C)"),
+    ::esphome::esp_log_printf_(level, tag, __LINE__, ESPHOME_LOG_FORMAT("    %s: 0x%02X (%.2f°C)"),
              name, raw, celsius);
   }
   return left - sizeof(Temperature);

--- a/tests/native/test_get_climate_action.cpp
+++ b/tests/native/test_get_climate_action.cpp
@@ -5,9 +5,9 @@
 // the esphome climate enums and logging macros it needs.
 //
 // Build & run (from the repository root, output kept out of the tree):
-//   g++ -std=c++17 -DUSE_ARDUINO \
-//       -Itests/native/stubs -Iesphome/components/midea_xye \
-//       tests/native/test_get_climate_action.cpp \
+//   g++ -std=c++17 -DUSE_ARDUINO
+//       -Itests/native/stubs -Iesphome/components/midea_xye
+//       tests/native/test_get_climate_action.cpp
 //       esphome/components/midea_xye/xye_adapter.cpp -o /tmp/xye_native_tests
 //   /tmp/xye_native_tests
 


### PR DESCRIPTION
## Summary

GCC emits `warning: hex escape sequence out of range` for the setpoint debug log strings introduced in #127:

```
src/esphome/components/midea_xye/xye_recv.cpp:48:73: warning: hex escape sequence out of range
   48 |     ::esphome::esp_log_printf_(level, tag, __LINE__,
       ESPHOME_LOG_FORMAT("    %s: 0x%02X (%d\xc2\xb0F / %.2f\xc2\xb0C)"),
```

**Root cause:** `\x` in a C++ string literal greedily consumes every following hex digit (C++17 [lex.ccon] p7). `\xc2\xb0F` is parsed as a single escape `\xc2b0F` (5 hex digits), not as the three bytes `\xc2`, `\xb0`, `F`. Same for `\xc2\xb0C`. The resulting value overflows `char`, hence the warning. The intent was the UTF-8 encoding of `°` (U+00B0 = `0xC2 0xB0`).

At runtime the log line would render as `(65<garbage> / 18.33<garbage>)` instead of `(65°F / 18.33°C)` — the F/C labels are consumed by the escape and the second UTF-8 byte is truncated. No memory safety impact (string length, format specifiers, and arg count are all unchanged) — purely cosmetic.

**Fix (`xye_recv.cpp`):** Use the literal `°` character directly in the format string, matching the convention already used in `xye.cpp::Temperature::print_debug`:

```cpp
ESPHOME_LOG_FORMAT("    %s: 0x%02X (%.2f°C)")
```

No behavioral change — the bytes on the wire are identical (`0xC2 0xB0` either way). Just eliminates the warning and aligns with the existing style in this codebase.

## Why CI did not catch this

Two reasons:

1. **Native test job didn't compile `xye_recv.cpp`** — only `xye_adapter.cpp` was in the source list.
2. **`esphome compile` printed the warning but exited 0**, so the green check went up. Nothing in the workflow scans build output for `warning:`.

**Fix (`.github/workflows/ci.yml`):** Add a `Lint component sources for warnings` step that runs `g++ -fsyntax-only -Wall -Werror` against each midea_xye `.cpp` file that compiles cleanly with the existing native stubs (`xye`, `xye_recv`, `xye_send`, `xye_adapter`). Also promote the existing adapter unit tests to `-Werror`. `climate_midea_xye.cpp` is intentionally excluded for now — it pulls in more ESPHome surface area than the stubs currently provide; extend the list as stubs grow.

This catches lexer/parser/semantic warnings on sources the unit tests don't link against — the exact gap that let the greedy-escape bug slip through.

## Test plan

- [ ] CI passes (ESPHome Build + Native Unit Tests, including the new lint step)
- [ ] No more `hex escape sequence out of range` warning in the build
- [ ] Debug log still renders `°F` / `°C` correctly on a connected unit
- [ ] Verify the new lint step would have failed on the pre-fix `xye_recv.cpp` (manually reproducible by reverting the source change locally)