### PR TITLE
fix: recover from WAIT_DATA deadlock on bad/missing response

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -169,8 +169,18 @@ void ClimateMideaXYE::sendRecv(uint8_t cmdSent) {
         }
       }
     } else {
-      ESP_LOGE(Constants::TAG, "Received incorrect message length from AC for Command %02X", cmdSent);
-      rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_ERROR);
+      ESP_LOGW(Constants::TAG, "Bad response length (%u bytes, expected %u) for Command %02X; resyncing",
+               i, RX_MESSAGE_LENGTH, cmdSent);
+      rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_WARN);
+      // Recover instead of deadlocking in WAIT_DATA: a missed, short, or
+      // over-long reply must not strand the state machine. Honor any queued
+      // command, otherwise restart the poll cycle on the next update().
+      if (queuedCommand != ControlState::WAIT_DATA) {
+        controlState = queuedCommand;
+        queuedCommand = ControlState::WAIT_DATA;
+      } else {
+        controlState = ControlState::SEND_QUERY;
+      }
     }
   });
 }


### PR DESCRIPTION
## Problem

The component stops transmitting permanently after running for a while — no periodic QUERY/SET reaches the wire, and Home Assistant commands are accepted by the climate base class but never produce UART output. Reported on ESP32 (ESPHome 2026.4–2026.5) and reproduced on an ESP8266 `d1_mini`, where it ran for ~10 minutes before going silent.

Fixes #134 (and appears to be the same root cause as #135).

## Root cause

`sendRecv()` enters `ControlState::WAIT_DATA` and schedules the `read-result` timeout. That callback only advances `controlState` out of `WAIT_DATA` when **exactly** `RX_MESSAGE_LENGTH` (32) bytes are buffered:

```cpp
if (i == RX_MESSAGE_LENGTH) {
  ... // only path that leaves WAIT_DATA
} else {
  ESP_LOGE(...);   // controlState stays WAIT_DATA — forever
}
```

Any other byte count — no reply, a short/partial reply, line noise, or more than 32 bytes — fell into the `else` branch, logged an error, and left the state machine in `WAIT_DATA`. `update()` treats `WAIT_DATA` as a no-op, and there is no other recovery path, so a single non-conforming response wedged the component permanently. Once stuck, HA commands only set `queuedCommand`, which is drained exclusively in the success branch that never runs again.

A tight `timeout` makes this likely in normal operation: 32 bytes at 4800 baud need ~66.7 ms to clock in before the unit's turnaround, so the default `100ms` window is regularly missed under loop/WiFi jitter — and each miss is fatal rather than a dropped cycle.

## Fix

The error branch now releases the state machine instead of stranding it: honor a queued command if one is pending, otherwise restart the poll cycle via `SEND_QUERY` on the next `update()`. A dropped/garbled response now costs a single cycle. Log level dropped from `ESP_LOGE` to `ESP_LOGW` since this is now recoverable.

## Verification

- Confirmed on hardware (ESP8266 `d1_mini`, Lennox unit, RS-485 @ 4800 baud): stable for >1 hour after the fix, where it previously went silent within ~10 minutes.
- CI compiles both `tests/midea_xye.yaml` (ESP8266) and `tests/midea_xye_esp32.yaml` (ESP32). Note the native unit-test/lint jobs intentionally exclude `climate_midea_xye.cpp`, so the ESPHome compile is the relevant build gate for this change.
- No schema or documented-behaviour change, so no `climate.py`/README/PROTOCOL updates are needed.
