### PR TITLE
fix: log no-response at DEBUG instead of WARN to avoid silent-bus spam

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -169,9 +169,19 @@ void ClimateMideaXYE::sendRecv(uint8_t cmdSent) {
         }
       }
     } else {
-      ESP_LOGW(Constants::TAG, "Bad response length (%u bytes, expected %u) for Command %02X; resyncing",
-               i, RX_MESSAGE_LENGTH, cmdSent);
-      rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_WARN);
+      // Distinguish a true no-reply from a corrupt/partial frame. On a silent
+      // bus (wrong unit address, miswired/unterminated bus, or no unit present)
+      // this branch fires every poll cycle, so logging the expected 0-byte case
+      // at WARN would spam a warning every ~second. Log no-reply at DEBUG and
+      // reserve WARN for an actual short/over-long frame, which is genuinely
+      // suspicious and worth surfacing.
+      if (i == 0) {
+        ESP_LOGD(Constants::TAG, "No response for command %02X", cmdSent);
+      } else {
+        ESP_LOGW(Constants::TAG, "Bad response length (%u bytes, expected %u) for Command %02X; resyncing",
+                 i, RX_MESSAGE_LENGTH, cmdSent);
+        rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_WARN);
+      }
       // Recover instead of deadlocking in WAIT_DATA: a missed, short, or
       // over-long reply must not strand the state machine. Honor any queued
       // command, otherwise restart the poll cycle on the next update().


### PR DESCRIPTION
## Summary

Follow-up to #136. That PR fixed the `WAIT_DATA` deadlock (great), but logs every non-conforming read at `WARN` — including the `i == 0` "no reply" case.

On a **persistently silent bus** — wrong unit address, miswired/unterminated bus, or a bench ESP with nothing attached — the recovery branch fires *every poll cycle*, so a `WARN` plus a `WARN`-level `rx_data.print_debug` dump is emitted roughly **once per second, indefinitely**. That's noise for an expected condition, and especially distracting during address bring-up / discovery where continuous silence is normal.

## Change

Split the recovery branch by case:

- `i == 0` (true no-reply) → `DEBUG`
- short / over-long frame → keep `WARN` + buffer dump (genuinely suspicious, worth surfacing)

**Recovery behaviour is unchanged** — only the log level of the no-reply path moves.

## Testing

- Native unit tests pass locally.
- CI `esphome compile` (ESP8266 + ESP32) is the relevant gate for this file (native jobs exclude `climate_midea_xye.cpp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
