### PR TITLE
feat: add configurable unit address for centralised-control bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ The component will automatically:
 climate:
   - platform: midea_xye
     name: Heatpump
+    address: 0x00               # Optional. Defaults to 0x00. Destination unit ID =
+                                # the indoor unit's centralised-control / network
+                                # address (its rotary "address" dial, 0x00..0x3F).
+                                # Set this to match the dial when one ESP drives one
+                                # indoor unit whose dial is not 0 (e.g. a multi-unit
+                                # system where each unit has a unique dial).
     period: 1s                  # Optional. Defaults to 1s
     timeout: 100ms              # Optional. Defaults to 100ms
     use_fahrenheit: false       # Optional. Defaults to false

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -5,6 +5,7 @@ from esphome.components.remote_base import CONF_TRANSMITTER_ID
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
+    CONF_ADDRESS,
     CONF_AUTOCONF,
     CONF_BEEPER,
     CONF_CUSTOM_FAN_MODES,
@@ -139,6 +140,10 @@ CONFIG_SCHEMA = cv.All(
     climate.climate_schema(ClimateMideaXYE).extend(
         {
             cv.GenerateID(): cv.declare_id(ClimateMideaXYE),
+            # Destination unit ID = the unit's centralised-control rotary-dial
+            # address (0..0x3F per protocol; a single hex dial covers 0x0..0xF).
+            # Defaults to 0x00 for a single unit on a private bus.
+            cv.Optional(CONF_ADDRESS, default=0): cv.int_range(min=0, max=0x3F),
             cv.Optional(CONF_PERIOD, default="1s"): cv.time_period,
             cv.Optional(CONF_TIMEOUT, default="100ms"): cv.time_period,
             cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
@@ -390,6 +395,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
     await climate.register_climate(var, config)
+    cg.add(var.set_address(config[CONF_ADDRESS]))
     cg.add(var.set_period(config[CONF_PERIOD].total_milliseconds))
     cg.add(var.set_response_timeout(config[CONF_TIMEOUT].total_milliseconds))
     cg.add(var.set_use_fahrenheit(config[CONF_USE_FAHRENHEIT]))

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -100,7 +100,7 @@ void ClimateMideaXYE::setPowerState(bool state) {
 }
 
 void ClimateMideaXYE::setTransmitParams() {
-  tx_data = TransmitData(Command::SET);
+  tx_data = TransmitData(Command::SET, this->address_);
   auto &d = tx_data.message.data.standard;
 
   d.operation_mode = XYEAdapter::get_operation_mode(this->mode);
@@ -225,14 +225,14 @@ void ClimateMideaXYE::update() {
       break;
     }
     case ControlState::SEND_QUERY: {
-      tx_data = TransmitData(Command::QUERY);
+      tx_data = TransmitData(Command::QUERY, this->address_);
       tx_data.update_crc();
       cmdSent = CLIENT_COMMAND_QUERY;
       sendRecv(cmdSent);
       break;
     }
     case ControlState::SEND_QUERY_EXTENDED: {
-      tx_data = TransmitData(Command::QUERY_EXTENDED);
+      tx_data = TransmitData(Command::QUERY_EXTENDED, this->address_);
       tx_data.update_crc();
       cmdSent = CLIENT_COMMAND_QUERY_EXTENDED;
       sendRecv(cmdSent);
@@ -495,7 +495,7 @@ void ClimateMideaXYE::do_follow_me(float temperature, bool beeper) {
   this->transmitter_.transmit(data);
 #else
   // Prepare Follow-Me command for temperature update
-  tx_data = TransmitData(Command::FOLLOW_ME);
+  tx_data = TransmitData(Command::FOLLOW_ME, this->address_);
   auto &d = tx_data.message.data.standard;
 
   // timer_stop is a subcommand type field for Follow-Me commands.
@@ -529,7 +529,7 @@ void ClimateMideaXYE::set_static_pressure(uint8_t static_pressure) {
   }
 
   // Prepare Follow-Me command for static pressure setting
-  tx_data = TransmitData(Command::FOLLOW_ME);
+  tx_data = TransmitData(Command::FOLLOW_ME, this->address_);
   auto &d = tx_data.message.data.standard;
   d.target_temperature.value = static_cast<uint8_t>(STATIC_PRESSURE_FLAG | (static_pressure & STATIC_PRESSURE_VALUE_MASK));
   d.timer_stop = FOLLOWME_SUBCOMMAND_STOP;

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -123,6 +123,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void set_uart_parent(uart::UARTComponent *parent) { this->uart_ = parent; }
   void set_period(uint32_t ms) { this->set_update_interval(ms); }
   void set_response_timeout(uint32_t ms) { this->response_timeout = ms; }
+  /// Destination unit ID (the unit's centralised-control / rotary-dial address,
+  /// 0x00..0x3F). Every frame this component transmits is addressed here.
+  void set_address(uint8_t address) { this->address_ = address; }
 
   /* Component methods */
 
@@ -193,6 +196,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   uint8_t ForceReadNextCycle;
   ControlState queuedCommand;
   uint32_t response_timeout;
+  // Destination unit ID for every transmitted frame (the unit's centralised-control
+  // / rotary-dial address). Defaults to 0x00 to preserve legacy single-unit behaviour.
+  uint8_t address_{0x00};
   // Tracks whether Follow-Me has been initialized after mode change.
   // When false, the next Follow-Me update sends an INIT subcommand (0x06).
   // When true, Follow-Me updates send a regular UPDATE subcommand (0x02).

--- a/esphome/components/midea_xye/xye_send.cpp
+++ b/esphome/components/midea_xye/xye_send.cpp
@@ -46,10 +46,10 @@ size_t TransmitData::print_debug(const char *tag, size_t left, int level) const 
   return left;
 }
 
-TransmitData::TransmitData(Command cmd) noexcept {
+TransmitData::TransmitData(Command cmd, NodeId server_id) noexcept {
   message.frame.preamble = ProtocolMarker::PREAMBLE;
   message.frame.header.command = cmd;
-  message.frame.header.server_id = SERVER_ID;
+  message.frame.header.server_id = server_id;
   message.frame.header.client_id1 = CLIENT_ID;
   message.frame.header.direction_node.direction = Direction::FROM_CLIENT;
   message.frame.header.direction_node.node_id = CLIENT_ID;

--- a/esphome/components/midea_xye/xye_send.h
+++ b/esphome/components/midea_xye/xye_send.h
@@ -89,7 +89,11 @@ union TransmitData {
   /// Sets preamble, command, node IDs, direction, complement, prologue, and
   /// zeros out all payload fields.  Call update_crc() afterwards to seal the
   /// message before transmission.
-  explicit TransmitData(Command cmd) noexcept;
+  /// @param cmd Command to build the frame for.
+  /// @param server_id Destination unit ID (the unit's centralised-control
+  ///        address, e.g. its rotary dial setting, 0x00..0x3F). Defaults to
+  ///        SERVER_ID (0x00). The source/master ID stays CLIENT_ID.
+  explicit TransmitData(Command cmd, NodeId server_id = SERVER_ID) noexcept;
 
   /// Recompute and store the CRC byte based on the current buffer contents.
   void update_crc() noexcept;


### PR DESCRIPTION
## Summary

Adds a configurable destination unit address so one ESP can talk to an indoor unit whose centralised-control / network address (its rotary "address" dial) is **not** `0`.

Previously the component hard-coded the destination ID to `0x00` (`SERVER_ID`), so it could only reach a unit whose dial was `0`. On multi-unit systems each indoor has a unique dial (e.g. `1`–`5`), making any non-zero unit unreachable — the component polls `0x00`, the unit listens at its dial value, nothing replies.

## Change

- New `address:` option, `0x00`–`0x3F` (a single hex dial covers `0x0`–`0xF`), default `0x00` → **fully backward-compatible**.
- Threaded through to the `server_id` of every transmitted frame: `QUERY`, `QUERY_EXTENDED`, `SET`, `FOLLOW_ME`.
- `TransmitData(Command)` gains an optional `NodeId server_id = SERVER_ID` parameter; the source/master ID is unchanged.
- Receive parsing is untouched — `ReceiveData::is_valid()` validates preamble/prologue/direction/CRC, not the address, so replies from a non-zero unit parse normally.

```yaml
climate:
  - platform: midea_xye
    name: IDU 1
    address: 0x01      # = the unit's rotary address dial
```

## Use case

One ESP per indoor unit, each on that unit's own X/Y/E (CCM) terminals — no shared bus, no central controller, no renumbering of the existing system. Each ESP simply targets its unit's dial.

## Notes / scope

- This does **not** auto-discover the address; it's a manual setting that must match the dial. Auto-discovery + a `discovered_address` diagnostic sensor is a planned follow-up.
- On an isolated one-unit-per-ESP bus, each unit can keep its existing unique dial; the ESP targets it directly.

## Testing

- Native unit tests pass locally.
- CI `esphome compile` (ESP8266 + ESP32) is the relevant gate for `climate_midea_xye.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
