### PR TITLE
feat: auto-discover the unit address when the bus is unresponsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ climate:
                                 # Set this to match the dial when one ESP drives one
                                 # indoor unit whose dial is not 0 (e.g. a multi-unit
                                 # system where each unit has a unique dial).
+    auto_discover: false        # Optional. Defaults to false. When the configured
+                                # address is unresponsive for `discovery_after` cycles,
+                                # sweep 0x00..0x3F with read-only C0 probes and adopt the
+                                # first unit that answers. Intended for an isolated
+                                # one-ESP-per-unit bus; do not enable on a bus shared with
+                                # a CCM/other controller.
+    discovery_after: 10         # Optional. Defaults to 10. Consecutive unanswered polls
+                                # before an address sweep starts.
+    discovered_address:         # Optional. Diagnostic sensor reporting the address
+      name: XYE Address         # auto-discovery locked onto (the unit's dial value).
     period: 1s                  # Optional. Defaults to 1s
     timeout: 100ms              # Optional. Defaults to 100ms
     use_fahrenheit: false       # Optional. Defaults to false

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -70,6 +70,9 @@ CONF_COMPRESSOR_ACTIVE = "compressor_active"
 CONF_FAN_SPEED = "fan_speed"
 CONF_COMPRESSOR_AWARE_ACTION = "compressor_aware_action"
 CONF_SYNC_FAN_MODE_FROM_DEVICE = "sync_fan_mode_from_device"
+CONF_AUTO_DISCOVER = "auto_discover"
+CONF_DISCOVERY_AFTER = "discovery_after"
+CONF_DISCOVERED_ADDRESS = "discovered_address"
 midea_xye_ns = cg.esphome_ns.namespace("midea").namespace("xye")
 ClimateMideaXYE = midea_xye_ns.class_("ClimateMideaXYE", climate.Climate, cg.Component)
 StaticPressureNumber = midea_xye_ns.class_("StaticPressureNumber", number.Number, cg.Component)
@@ -155,6 +158,11 @@ CONFIG_SCHEMA = cv.All(
             # physical thermostat), so Home Assistant reflects fan mode changes even when
             # not triggered by an HA command.
             cv.Optional(CONF_SYNC_FAN_MODE_FROM_DEVICE, default=False): cv.boolean,
+            # Opt-in: if the configured address is unresponsive for `discovery_after`
+            # poll cycles, sweep the address range with read-only C0 probes and adopt
+            # the first unit that answers. For an isolated one-unit-per-ESP bus.
+            cv.Optional(CONF_AUTO_DISCOVER, default=False): cv.boolean,
+            cv.Optional(CONF_DISCOVERY_AFTER, default=10): cv.int_range(min=1, max=1000),
             cv.OnlyWith(CONF_TRANSMITTER_ID, "remote_transmitter"): cv.use_id(
                 remote_transmitter.RemoteTransmitterComponent
             ),
@@ -189,6 +197,12 @@ CONFIG_SCHEMA = cv.All(
                 icon="mdi:fan",
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            # Publishes the unit address that auto-discovery locked onto (its dial value).
+            cv.Optional(CONF_DISCOVERED_ADDRESS): sensor.sensor_schema(
+                icon="mdi:identifier",
+                accuracy_decimals=0,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(
@@ -396,6 +410,8 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     await climate.register_climate(var, config)
     cg.add(var.set_address(config[CONF_ADDRESS]))
+    cg.add(var.set_auto_discover(config[CONF_AUTO_DISCOVER]))
+    cg.add(var.set_discovery_after(config[CONF_DISCOVERY_AFTER]))
     cg.add(var.set_period(config[CONF_PERIOD].total_milliseconds))
     cg.add(var.set_response_timeout(config[CONF_TIMEOUT].total_milliseconds))
     cg.add(var.set_use_fahrenheit(config[CONF_USE_FAHRENHEIT]))
@@ -429,6 +445,9 @@ async def to_code(config):
     if CONF_FAN_SPEED in config:
         sens = await sensor.new_sensor(config[CONF_FAN_SPEED])
         cg.add(var.set_fan_speed_sensor(sens))
+    if CONF_DISCOVERED_ADDRESS in config:
+        sens = await sensor.new_sensor(config[CONF_DISCOVERED_ADDRESS])
+        cg.add(var.set_discovered_address_sensor(sens))
     if CONF_TEMPERATURE_2A in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_2A])
         cg.add(var.set_temperature_2a_sensor(sens))

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -141,6 +141,9 @@ void ClimateMideaXYE::sendRecv(uint8_t cmdSent) {
       i++;
     }
     if (i == RX_MESSAGE_LENGTH) {
+      // The configured address answered: the bus is responsive, clear the miss
+      // counter so a transient gap never accumulates toward a needless sweep.
+      this->miss_count_ = 0;
       // Log incoming message at debug level
       rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_DEBUG, this->use_fahrenheit_);
       // Don't parse responses to SET or FOLLOW_ME commands to avoid
@@ -191,12 +194,86 @@ void ClimateMideaXYE::sendRecv(uint8_t cmdSent) {
       } else {
         controlState = ControlState::SEND_QUERY;
       }
+      // After recovering, count this miss and (if enabled) start an address
+      // sweep once the bus has been unresponsive for discovery_after_ cycles.
+      this->maybe_start_discovery_();
     }
   });
 }
 
+void ClimateMideaXYE::maybe_start_discovery_() {
+  // Called from the no-response path. Count consecutive unanswered polls and,
+  // when auto-discovery is enabled and the bus has stayed silent long enough,
+  // kick off an address sweep. Only runs while the configured address is dead.
+  if (!this->auto_discover_ || this->discovering_)
+    return;
+  if (++this->miss_count_ < this->discovery_after_)
+    return;
+  this->discovering_ = true;
+  this->scan_addr_ = this->scan_min_;
+  ESP_LOGW(Constants::TAG, "Address 0x%02X unresponsive for %u cycles; scanning 0x%02X-0x%02X for a unit",
+           this->address_, this->miss_count_, this->scan_min_, this->scan_max_);
+  this->send_probe_();
+}
+
+void ClimateMideaXYE::send_probe_() {
+  // Send one C0 (QUERY) to the current scan address and wait response_timeout.
+  // A CRC-valid reply whose source ID matches the probed address means a unit
+  // lives there. The sweep chains via set_timeout, so it runs at ~response_timeout
+  // per address independent of the (slower) poll period; normal polling stays
+  // suspended (see update()) so only one frame is ever in flight.
+  //
+  // Drop any stale bytes first (e.g. a late reply to the previous probe) so this
+  // probe's read window only sees a response to this address.
+  uint8_t stale;
+  while (this->uart_->available())
+    this->uart_->read_byte(&stale);
+  this->tx_data = TransmitData(Command::QUERY, this->scan_addr_);
+  this->tx_data.update_crc();
+  this->tx_data.print_debug(Constants::TAG, TX_MESSAGE_LENGTH, ESPHOME_LOG_LEVEL_DEBUG);
+  this->uart_->write_array(this->tx_data.raw, TX_MESSAGE_LENGTH);
+  this->uart_->flush();
+  this->set_timeout("discover-read", this->response_timeout, [this]() {
+    uint8_t i = 0;
+    while (this->uart_->available()) {
+      if (i < RX_MESSAGE_LENGTH)
+        this->uart_->read_byte(&this->rx_data.raw[i]);
+      i++;
+    }
+    const bool found = (i == RX_MESSAGE_LENGTH) && this->rx_data.is_valid() &&
+                       (this->rx_data.message.frame.header.source == this->scan_addr_);
+    if (found) {
+      this->finish_discovery_(true, this->scan_addr_);
+    } else if (this->scan_addr_ >= this->scan_max_) {
+      this->finish_discovery_(false, 0x00);
+    } else {
+      this->scan_addr_++;
+      this->set_timeout("discover-gap", 10, [this]() { this->send_probe_(); });
+    }
+  });
+}
+
+void ClimateMideaXYE::finish_discovery_(bool found, uint8_t addr) {
+  this->discovering_ = false;
+  this->miss_count_ = 0;
+  if (found) {
+    ESP_LOGI(Constants::TAG, "Discovered unit at address 0x%02X (was polling 0x%02X); adopting it", addr,
+             this->address_);
+    this->address_ = addr;
+    set_sensor(this->discovered_address_sensor_, static_cast<float>(addr));
+  } else {
+    ESP_LOGW(Constants::TAG, "Address scan found no unit in 0x%02X-0x%02X; resuming polls at 0x%02X",
+             this->scan_min_, this->scan_max_, this->address_);
+  }
+  this->controlState = ControlState::SEND_QUERY;
+}
+
 void ClimateMideaXYE::update() {
   uint8_t cmdSent = 0x00;
+  // While an address sweep is running it drives itself via chained timeouts;
+  // suspend the normal poll cycle so there is never more than one frame in flight.
+  if (this->discovering_)
+    return;
   // Possible States:
   // 0: Waiting for Response from Command
   // 1: Sending Set C3 Command

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -126,6 +126,12 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   /// Destination unit ID (the unit's centralised-control / rotary-dial address,
   /// 0x00..0x3F). Every frame this component transmits is addressed here.
   void set_address(uint8_t address) { this->address_ = address; }
+  /// Opt-in: when the configured address is unresponsive for `discovery_after`
+  /// poll cycles, sweep the address range with C0 probes and adopt the first
+  /// unit that answers. Intended for an isolated one-unit-per-ESP bus.
+  void set_auto_discover(bool yesno) { this->auto_discover_ = yesno; }
+  void set_discovery_after(uint16_t cycles) { this->discovery_after_ = cycles; }
+  void set_discovered_address_sensor(Sensor *sensor) { this->discovered_address_sensor_ = sensor; }
 
   /* Component methods */
 
@@ -166,6 +172,12 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void setup() override;
   void loop() override {}
   void sendRecv(uint8_t cmdSent);
+  // Auto-discovery of the unit address (opt-in). maybe_start_discovery_ counts
+  // misses and kicks off a sweep; send_probe_ probes one address and chains to
+  // the next; finish_discovery_ adopts a found address (or gives up) and resumes.
+  void maybe_start_discovery_();
+  void send_probe_();
+  void finish_discovery_(bool found, uint8_t addr);
   void setPowerState(bool state);
   void setTransmitParams();
 
@@ -199,6 +211,14 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   // Destination unit ID for every transmitted frame (the unit's centralised-control
   // / rotary-dial address). Defaults to 0x00 to preserve legacy single-unit behaviour.
   uint8_t address_{0x00};
+  // --- Auto-discovery (opt-in via auto_discover) ---
+  bool auto_discover_{false};       // enable an address sweep when unresponsive
+  uint8_t scan_min_{0x00};          // inclusive low end of the sweep range
+  uint8_t scan_max_{0x3F};          // inclusive high end (protocol max device ID)
+  uint16_t discovery_after_{10};    // consecutive misses before a sweep starts
+  uint16_t miss_count_{0};          // consecutive unanswered polls (normal mode)
+  bool discovering_{false};         // true while a sweep is in progress
+  uint8_t scan_addr_{0x00};         // address currently being probed
   // Tracks whether Follow-Me has been initialized after mode change.
   // When false, the next Follow-Me update sends an INIT subcommand (0x06).
   // When true, Follow-Me updates send a regular UPDATE subcommand (0x02).
@@ -246,6 +266,8 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
 #endif
   Sensor *follow_me_sensor_{nullptr};
   Sensor *internal_current_temperature_sensor_{nullptr};
+  // Publishes the address auto-discovery locked onto (the unit's dial value).
+  Sensor *discovered_address_sensor_{nullptr};
   StaticPressureNumber *static_pressure_number_{nullptr};
   ClimateMode last_on_mode_;
   float internal_temperature_{NAN};

--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -36,6 +36,9 @@ climate:
   - platform: midea_xye
     id: main_climate
     name: Test Heatpump
+    address: 0x01
+    auto_discover: true
+    discovery_after: 5
     period: 1s
     timeout: 100ms
     use_fahrenheit: false
@@ -44,6 +47,8 @@ climate:
       name: "Internal Current Temperature"
     fan_speed:
       name: "Fan Speed"
+    discovered_address:
+      name: "XYE Address"
     defrost:
       name: "Defrost Active"
     compressor_active:

--- a/tests/midea_xye_esp32.yaml
+++ b/tests/midea_xye_esp32.yaml
@@ -38,12 +38,17 @@ climate:
   - platform: midea_xye
     id: main_climate
     name: Test Heatpump
+    address: 0x01
+    auto_discover: true
+    discovery_after: 5
     period: 1s
     timeout: 100ms
     use_fahrenheit: false
     follow_me_sensor: test_sensor  # Automatically updates follow_me from this sensor
     internal_current_temperature:
       name: "Internal Current Temperature"
+    discovered_address:
+      name: "XYE Address"
     defrost:
       name: "Defrost Active"
 


### PR DESCRIPTION
## Summary

Adds **opt-in auto-discovery** of the unit address. When the configured `address` is unresponsive for a while, the component sweeps the address range with read-only `C0` (QUERY) probes, adopts the first unit that answers, and reports it via an optional `discovered_address` sensor.

Builds on the configurable `address` / `server_id` plumbing (#141).

## Behaviour

- **Trigger:** only from the no-response path — after `discovery_after` consecutive unanswered polls (default `10`). A responsive bus never scans.
- **Sweep:** `0x00`–`0x3F` with `C0` probes. A probe "hits" when the reply is `is_valid()` (CRC/preamble/prologue/direction) **and** its source ID equals the probed address.
- **On found:** adopt it (`address_ = found`), resume normal `C0→C4` polling there, and publish to `discovered_address`.
- **On not found:** log and resume polling the configured address (which re-triggers a sweep after `discovery_after` again — self-retrying).

## Design notes

- The sweep **chains via `set_timeout` (~`timeout` per address)**, so it completes in ~seconds regardless of the slower poll `period`. `update()` suspends normal polling while a sweep runs, so there's never more than one frame in flight.
- Each probe **drains stale RX first** and verifies the reply's source ID, so a delayed reply to the previous probe can't cause a wrong-address adoption.
- `C0` is read-only → probing addresses with no unit is harmless.

## Scope / caveats

- Intended for an **isolated one-ESP-per-unit bus** (a unit answers only its own address). On a bus shared with a CCM/other controller the sweep injects probes to many addresses and would lock the first responder — **documented as isolated-bus-only**.
- Default `auto_discover: false` → zero behaviour change for existing users.

## Config

```yaml
climate:
  - platform: midea_xye
    address: 0x01            # starting hint
    auto_discover: true      # off by default
    discovery_after: 10      # misses before a sweep (optional)
    discovered_address:      # optional diagnostic sensor
      name: XYE Address
```

## Testing

- Native unit tests pass locally; `climate.py` parses.
- CI `esphome compile` (ESP8266 + ESP32) is the build gate for `climate_midea_xye.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
