### PR TITLE
docs: require narrow, single-purpose pull requests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,16 @@ This repository contains an ESPHome external component for controlling Midea HVA
 - Ensure CI passes before requesting review
 - Update tests to cover new functionality
 
+### Pull Request Scope (Required)
+
+**Every PR must address exactly one concern.** Do not bundle unrelated changes. A PR that mixes, for example, a new feature with documentation rewrites, build/version-stamping tooling, or unrelated renames **will be rejected and returned for splitting**.
+
+- One logical change per PR. If the description needs the word "and", split it.
+- Documentation-only changes go in a separate `docs:` PR.
+- Build/tooling/logging scaffolding that the feature does not require goes in its own PR.
+- Keep each diff small enough that a reviewer can hold its single purpose in their head.
+- Prefer several small PRs over one large one, even when every part is individually useful.
+
 ### Conventional Commits (Required)
 
 All PR titles and commit messages **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. release-please uses these to automatically determine the next version and generate changelogs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+Guidance for AI coding agents (Claude, GitHub Copilot, and similar) working in this
+repository. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide; the
+rules below are mandatory for agent-generated changes.
+
+## Pull requests must be narrow and single-purpose
+
+**Every PR must address exactly one concern.** A PR that bundles unrelated changes — for
+example a feature together with documentation rewrites, build/version-stamping tooling, or
+unrelated field renames — **will be rejected and must be split**.
+
+- One logical change per PR. If you need "and" to describe it, it is two PRs.
+- Documentation-only changes go in their own `docs:` PR.
+- Build/tooling/logging scaffolding that the feature does not require goes in its own PR.
+- Wide renames or refactors go in their own PR, separate from behavioural changes.
+- Prefer several small PRs over one large one, even when every part is individually useful.
+
+## Conventional Commits (required)
+
+PR titles and commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/)
+(`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `perf:`). `release-please`
+uses them to determine the next version and generate the changelog. GitHub squash-merge uses
+the PR title as the commit subject, so the title must match the format.
+
+## Before opening a PR
+
+- Keep the Python schema (`climate.py`) in sync with the C++ implementation; add schema
+  validation for every new config key.
+- Never use bare numeric literals for protocol values, byte offsets, or flag masks — define
+  a named `constexpr` in `xye.h` (protocol-level) or `climate_midea_xye.h`
+  (implementation-level), with a doc comment.
+- Compile both test configurations:
+  `esphome compile tests/midea_xye.yaml` and `esphome compile tests/midea_xye_esp32.yaml`.
+- Exercise any new config key in at least one test YAML.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for taking the time to contribute! This document explains how to set u
 - [Code Style](#code-style)
 - [Testing](#testing)
 - [Commit Messages](#commit-messages)
+- [Scope of a Pull Request](#scope-of-a-pull-request)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Reporting Issues](#reporting-issues)
 
@@ -135,6 +136,28 @@ chore: update CI workflow for ESPHome compile checks
 
 > **Important:** GitHub squash-merges use the PR title as the commit message.  
 > Always set the PR title to match the conventional commit format above.
+
+---
+
+## Scope of a Pull Request
+
+**Each pull request must address exactly one concern.** Narrow, single-purpose PRs are reviewed faster, bisect cleanly, and produce an accurate changelog. A PR that bundles unrelated changes — however useful each part is on its own — will be returned to be split before it is reviewed.
+
+The following do **not** belong in the same PR and must be split apart:
+
+- A new feature and unrelated documentation rewrites.
+- A new feature and build/tooling/logging scaffolding (e.g. version-stamping) that the feature does not require.
+- Two independent features or fixes.
+- Field/sensor renames or comment cleanups mixed into a behavioural change.
+
+Guidelines:
+
+- One logical change per PR. If you need the word "and" to describe it, it is probably two PRs.
+- Documentation-only changes go in their own `docs:` PR.
+- Wide renames or refactors go in their own `refactor:`/`docs:` PR, landed before or after the behavioural change so the behavioural diff stays small and readable.
+- Keep each diff small enough that a reviewer can hold its single purpose in their head.
+
+> Open the pieces as separate PRs and link them together. A large, multi-purpose PR will be asked to be split before review.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit **single-purpose PR policy** to the contributor guide and mirrors it as mandatory directives for AI coding agents.

Motivation: large PRs that bundle a feature with unrelated documentation rewrites and build/version-stamping tooling are hard to review, bisect poorly, and pollute the changelog (see #137). This makes the expectation explicit and gives reviewers a documented basis for asking that such PRs be split.

## Changes

- **`CONTRIBUTING.md`** — new "Scope of a Pull Request" section: one concern per PR; docs-only changes go in their own `docs:` PR; wide renames land separately; multi-purpose PRs are returned to be split.
- **`.github/copilot-instructions.md`** — "Pull Request Scope (Required)" directive for GitHub Copilot.
- **`CLAUDE.md`** (new) — same narrow-PR directive plus Conventional Commits and pre-PR checklist for Claude / agent contributors.

Docs-only; no code or behaviour changes.