### PR TITLE
docs: correct indoor coil sensor naming and note Fahrenheit variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ climate:
                                         # The sensor is updated on state change and every 30 seconds
     outdoor_temperature:        # Optional. Outdoor temperature sensor
       name: Outside Temp
-    temperature_2a:             # Optional. Inside coil temperature
-      name: Inside Coil Inlet Temp
-    temperature_2b:             # Optional. Inside coil temperature
-      name: Inside Coil Outlet Temp
-    temperature_3:              # Optional. Outside coil temperature
+    temperature_2a:             # Optional. T2 indoor coil temperature
+      name: Indoor Coil Temp
+    temperature_2b:             # Optional. T2B indoor coil exhaust temperature (normally located in the outdoor unit, if installed)
+      name: Indoor Coil Exhaust Temp
+    temperature_3:              # Optional. T3 outdoor coil temperature
       name: Outside Coil Temp
     current:                    # Optional. Current measurement
       name: Current

--- a/esphome/components/midea_xye/PROTOCOL.md
+++ b/esphome/components/midea_xye/PROTOCOL.md
@@ -80,9 +80,10 @@ Byte    Field               Description
                             status flag unrelated to the temperature — it must be masked out
                             with SET_TEMP_VALUE_MASK (0xBF) before interpreting the value.
 11      T1 Temperature      Internal/room temperature sensor
-12      T2A Temperature     Indoor coil inlet temperature
-13      T2B Temperature     Indoor coil outlet temperature
-14      T3 Temperature      Outdoor coil/ambient temperature
+12      T2 Temperature      Indoor coil temperature. The code historically calls
+                            this `t2a_temperature`; service docs usually call it T2.
+13      T2B Temperature     Indoor coil exhaust temperature, if equipped (normally located in the outdoor unit, if installed)
+14      T3 Temperature      Outdoor coil temperature
 15      Current             Current draw (units unknown, often reads 0xFF)
 16      Unknown2            Unknown/reserved
 17      Timer Start         Start timer setting
@@ -312,6 +313,16 @@ celsius = (encoded_value - 0x28) / 2.0
 
 ### Fahrenheit Encoding
 Some implementations send raw Fahrenheit values directly without encoding. The behavior may depend on unit configuration or regional settings.
+
+Two Fahrenheit-related variants have been observed in the field:
+
+- **Offset Fahrenheit in C4**: the setpoint byte is `°F + 0x87`; this is what the
+  existing `use_fahrenheit: true` option handles.
+- **Raw temperature fields**: some units (for example certain C&H concealed-duct
+  models) appear to report temperature bytes as direct raw values (`0x46` = 70°F,
+  `0x45` = 69°F, …) rather than Midea's normal encoded Celsius, and may return an
+  unusable or sentinel-filled (`0xFF`) response to C4 extended queries. Decoding
+  support for these units is tracked separately from this protocol note.
 
 **Special Value**:
 - `0xFF`: Used in FAN mode when temperature control is not applicable

--- a/esphome/components/midea_xye/README.md
+++ b/esphome/components/midea_xye/README.md
@@ -71,11 +71,11 @@ climate:
       - VERTICAL
     outdoor_temperature:        # Optional. Outdoor temperature sensor
       name: Outside Temp
-    temperature_2a:             # Optional. Inside coil temperature
-      name: Inside Coil Inlet Temp
-    temperature_2b:             # Optional. Inside coil temperature
-      name: Inside Coil Outlet Temp
-    temperature_3:             # Optional. Outside coil temperature
+    temperature_2a:             # Optional. T2 indoor coil temperature
+      name: Indoor Coil Temp
+    temperature_2b:             # Optional. T2B indoor coil exhaust temperature (normally located in the outdoor unit, if installed)
+      name: Indoor Coil Exhaust Temp
+    temperature_3:             # Optional. T3 outdoor coil temperature
       name: Outside Coil Temp
     current:                    # Optional. Current measurement
       name: Current

--- a/esphome/components/midea_xye/RESEARCH_SUMMARY.md
+++ b/esphome/components/midea_xye/RESEARCH_SUMMARY.md
@@ -14,8 +14,8 @@ This research analyzed wtahler's esphome-mideaXYE-rs485 implementation and compa
 Successfully mapped all temperature sensors with their actual purposes:
 
 - **T1 (byte 11)**: Internal/inlet air temperature - room temperature
-- **T2A (byte 12)**: Indoor coil inlet temperature - refrigerant entering evaporator
-- **T2B (byte 13)**: Indoor coil outlet temperature - refrigerant leaving evaporator  
+- **T2 (byte 12; `t2a_temperature` in code)**: Indoor coil temperature
+- **T2B (byte 13)**: Indoor coil exhaust temperature, if equipped (normally located in the outdoor unit, if installed)
 - **T3 (byte 14)**: Outdoor coil/ambient temperature
 
 **Status**: ✅ Documented in code comments and PROTOCOL.md
@@ -104,7 +104,7 @@ Created `PROTOCOL.md` with:
 
 Updated header files with:
 - Protocol variation notes (AUTO/FAN_LOW)
-- Temperature sensor purposes (T1-T3, T2A-T2B)
+- Temperature sensor purposes (T1-T3, T2-T2B)
 - Absolute byte position comments
 - Temperature encoding formula with examples
 - Error flag clarifications
@@ -157,7 +157,7 @@ Added references to:
 
 This research successfully:
 - ✅ Validated current protocol implementation against wtahler's work
-- ✅ Documented temperature sensor mappings (T1, T2A, T2B, T3)
+- ✅ Documented temperature sensor mappings (T1, T2, T2B, T3)
 - ✅ Identified and documented protocol variations (AUTO/FAN_LOW)
 - ✅ Created comprehensive protocol documentation (PROTOCOL.md)
 - ✅ Enhanced code comments with practical information


### PR DESCRIPTION
## Summary

Recovers the genuinely useful, **merge-safe** documentation from #137 so it lands independently of that PR's (unrelated) code changes.

## Changes

- **Sensor naming** — aligns the byte 12/13/14 temperature fields with Midea service-manual naming across `PROTOCOL.md`, `RESEARCH_SUMMARY.md`, and both README sensor examples:
  - T2A → **T2** (indoor coil temperature; code field stays `t2a_temperature` for compatibility)
  - T2B → **indoor coil exhaust temperature** (normally in the outdoor unit, if installed)
  - T3 → **outdoor coil temperature**
- **Fahrenheit variants** — `PROTOCOL.md` now records the two observed Fahrenheit encodings: offset-F in C4 (`°F + 0x87`, handled by `use_fahrenheit`) and raw-byte temperature fields seen on some C&H concealed-duct units.

## Scope

Docs-only. Deliberately **excludes** the parts of #137's documentation that describe config keys not yet on `main` (`temperature_encoding`, `target_temperature_source`, `internal_target_temperature`) — those belong with the feature PR so the docs never describe options the merged code lacks.

Credit for the underlying research goes to @larsonm-personal (#137); a separate PR adds the acknowledgment.