### PR TITLE
fix: accept 0x80 reply-direction bit in received frames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
             -o "${RUNNER_TEMP}/xye_temp_tests"
           "${RUNNER_TEMP}/xye_temp_tests"
 
+          g++ -std=c++17 -Wall -Werror -DUSE_ARDUINO \
+            -Itests/native/stubs -Iesphome/components/midea_xye \
+            tests/native/test_is_valid.cpp \
+            esphome/components/midea_xye/xye_recv.cpp \
+            esphome/components/midea_xye/xye.cpp \
+            esphome/components/midea_xye/xye_adapter.cpp \
+            -o "${RUNNER_TEMP}/xye_is_valid_tests"
+          "${RUNNER_TEMP}/xye_is_valid_tests"
+
       - name: Lint component sources for warnings
         # Syntax-only check (-fsyntax-only) against the minimal native stubs.
         # Catches lexer/parser/semantic warnings (e.g. greedy \x hex escapes)

--- a/esphome/components/midea_xye/PROTOCOL.md
+++ b/esphome/components/midea_xye/PROTOCOL.md
@@ -67,8 +67,10 @@ Byte    Field               Description
 ----    -----               -----------
 0       Preamble            Always 0xAA
 1       Command             Response command type (echoes request command)
-2       Direction           Direction flag (0x00 in practice, though some docs specify 0x80).
-                            Messages are distinguished by context and command type, not this byte.
+2       Direction           Direction flag. Observed as either 0x00 or 0x80 depending on the
+                            unit (bit 7 = "this is a reply"). Messages are distinguished by
+                            context and command type, not this byte, so is_valid() masks off
+                            bit 7 and accepts both. See "Direction Flag" note below.
 3       Destination ID      Master/thermostat ID (0x00..0x3F)
 4       Source ID           Unit/device ID (0x00..0x3F)
 5       Destination ID      Master/thermostat ID (repeated)
@@ -525,9 +527,15 @@ The master (CCM/thermostat) uses a polling model:
 
 ### Direction Flag (Byte 2)
 - Some legacy/third-party protocol documentation (and some early tables) describe a direction flag bit, with 0x80 used for frames sent from the master and 0x00 for frames from the AC
-- Actual on-wire traffic for XYE/CCM units shows byte 2 as 0x00 for both requests (master → AC) and responses (AC → master)
-- This implementation always transmits 0x00 in byte 2 and expects 0x00 in responses, matching observed AC behavior
-- Any references to 0x80 in direction-flag fields elsewhere in this document should be interpreted as legacy/spec behavior, not what this component actually sends on the wire
+- On many XYE/CCM units, on-wire traffic shows byte 2 as 0x00 for both requests (master → AC) and responses (AC → master)
+- **However, this is not universal.** A real **MD17I-017HW** indoor unit on a live 5-indoor-unit Mini VRF system (outdoor **MD17I-004C / GDV-V160W**) was captured answering `C0` QUERY frames with byte 2 set to **0x80** — the legacy "this is a reply" bit. The rest of the frame was well-formed (correct preamble, prologue, and CRC) and carried valid live data. Example captured reply (unit address 0x01):
+
+  ```
+  <<< AA C0 80 00 01 00 E0 14 00 00 18 5C 34 36 FF FF 00 00 00 01 00 00 00 00 00 00 00 0A FF FF E6 55
+  ```
+
+- This implementation always **transmits 0x00** in byte 2. For **received** frames, `ReceiveData::is_valid()` masks off bit 7 (`direction & 0x7F`) before comparing, so both the 0x00 and 0x80 reply encodings validate. Before this fix, 0x80-replying units had every response rejected with `Received invalid response from AC` and never came online. Regression coverage: `tests/native/test_is_valid.cpp`.
+- Other references to 0x80 in direction-flag fields elsewhere in this document describe legacy/spec behavior; on the wire this component only ever *sends* 0x00, but it *accepts* 0x00 or 0x80.
 
 ### Temperature Encoding
 - Some units use raw Fahrenheit values without encoding

--- a/esphome/components/midea_xye/xye.h
+++ b/esphome/components/midea_xye/xye.h
@@ -35,9 +35,15 @@ constexpr uint8_t RX_MESSAGE_LENGTH = 32;  ///< Length of received messages
 /**
  * @brief Message direction indicators
  * 
- * Note: In actual AC implementations, both directions use 0x00 in the direction byte.
+ * Note: In many AC implementations, both directions use 0x00 in the direction byte.
  * Messages are distinguished by context (who initiated the communication) and command type,
- * not by the direction byte value. This matches v0.0.10 behavior and actual AC units.
+ * not by the direction byte value. This matches v0.0.10 behavior and those AC units.
+ *
+ * However, some units set bit 7 (0x80) of this byte on replies as a "this is a
+ * response" marker. A real MD17I-017HW indoor unit on a live 5-indoor-unit Mini
+ * VRF system (outdoor MD17I-004C / GDV-V160W) was captured answering C0 queries
+ * with direction 0x80. ReceiveData::is_valid() masks off bit 7 so both the 0x00
+ * and 0x80 reply encodings validate.
  */
 enum class Direction : uint8_t {
   FROM_CLIENT = 0x00,  ///< Message from client (thermostat) to server (HVAC)

--- a/esphome/components/midea_xye/xye_recv.cpp
+++ b/esphome/components/midea_xye/xye_recv.cpp
@@ -143,9 +143,14 @@ size_t ReceiveData::print_debug(size_t left, const char *tag, int level, bool us
 }
 
 bool ReceiveData::is_valid() const noexcept {
+  // Some units set bit 7 (0x80) of the direction byte as a "this is a reply"
+  // marker (0x80 instead of 0x00); mask it off so both encodings validate. Seen
+  // on a real MD17I-017HW indoor unit on a live 5-unit Mini VRF system, which
+  // answers C0 queries with direction 0x80. See tests/native/test_is_valid.cpp.
+  const uint8_t direction = static_cast<uint8_t>(message.frame.header.direction) & 0x7F;
   return message.frame.preamble == ProtocolMarker::PREAMBLE &&
          message.frame_end.prologue == ProtocolMarker::PROLOGUE &&
-         message.frame.header.direction == Direction::TO_CLIENT &&
+         direction == TO_CLIENT &&
          message.frame_end.crc == compute_protocol_crc(raw, RX_MESSAGE_LENGTH);
 }
 

--- a/tests/native/test_is_valid.cpp
+++ b/tests/native/test_is_valid.cpp
@@ -1,0 +1,101 @@
+// Host-side unit tests for ReceiveData::is_valid().
+//
+// Regression coverage for the reply-direction byte. A real Midea indoor unit on
+// a live 5-indoor-unit Mini VRF system (outdoor MD17I-004C / GDV-V160W, indoors
+// MD17I-017HW) was captured answering C0 QUERY frames with the direction byte
+// set to 0x80 (bit 7 = "this is a reply") rather than 0x00. is_valid() must
+// accept that frame; the exact bytes below are copied from that capture.
+//
+// Build & run (from the repository root, output kept out of the tree):
+//   g++ -std=c++17 -DUSE_ARDUINO
+//       -Itests/native/stubs -Iesphome/components/midea_xye
+//       tests/native/test_is_valid.cpp
+//       esphome/components/midea_xye/xye_recv.cpp
+//       esphome/components/midea_xye/xye.cpp
+//       esphome/components/midea_xye/xye_adapter.cpp -o /tmp/xye_is_valid_tests
+//   /tmp/xye_is_valid_tests
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "xye_recv.h"
+
+namespace {
+
+using esphome::midea::xye::ReceiveData;
+using esphome::midea::xye::RX_MESSAGE_LENGTH;
+
+int g_failures = 0;
+int g_checks = 0;
+
+// A genuine C0 QUERY response captured from a real MD17I-017HW indoor unit
+// (address 0x01) on a 5-unit VRF system. Note byte[2] == 0x80: the unit sets
+// the reply bit on the direction field. CRC (byte[30]) == 0xE6, prologue 0x55.
+const uint8_t REAL_UNIT_C0_REPLY[RX_MESSAGE_LENGTH] = {
+    0xAA, 0xC0, 0x80, 0x00, 0x01, 0x00, 0xE0, 0x14, 0x00, 0x00, 0x18,
+    0x5C, 0x34, 0x36, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xFF, 0xFF, 0xE6, 0x55};
+
+void expect(const char *desc, bool got, bool expected) {
+  g_checks++;
+  if (got != expected) {
+    g_failures++;
+    std::printf("FAIL: %s -- expected %s, got %s\n", desc, expected ? "valid" : "invalid",
+                got ? "valid" : "invalid");
+  } else {
+    std::printf("ok:   %s\n", desc);
+  }
+}
+
+ReceiveData from_bytes(const uint8_t (&bytes)[RX_MESSAGE_LENGTH]) {
+  ReceiveData rx;
+  std::memcpy(rx.raw, bytes, RX_MESSAGE_LENGTH);
+  return rx;
+}
+
+}  // namespace
+
+int main() {
+  std::printf("-- ReceiveData::is_valid --\n");
+
+  // The real-world frame with the reply bit set must validate.
+  expect("real MD17I-017HW C0 reply (direction 0x80)", from_bytes(REAL_UNIT_C0_REPLY).is_valid(), true);
+
+  // The same frame with a plain 0x00 direction (other units' encoding) still
+  // validates. Clearing bit 7 changes the CRC, so recompute it.
+  {
+    uint8_t bytes[RX_MESSAGE_LENGTH];
+    std::memcpy(bytes, REAL_UNIT_C0_REPLY, RX_MESSAGE_LENGTH);
+    bytes[2] = 0x00;                 // direction without the reply bit
+    bytes[30] = static_cast<uint8_t>(bytes[30] + 0x80);  // CRC = 0xFF - sum; dropping 0x80 raises it by 0x80
+    expect("C0 reply with plain 0x00 direction", from_bytes(bytes).is_valid(), true);
+  }
+
+  // A corrupted CRC must be rejected.
+  {
+    uint8_t bytes[RX_MESSAGE_LENGTH];
+    std::memcpy(bytes, REAL_UNIT_C0_REPLY, RX_MESSAGE_LENGTH);
+    bytes[30] ^= 0xFF;
+    expect("corrupted CRC is rejected", from_bytes(bytes).is_valid(), false);
+  }
+
+  // A bad preamble must be rejected.
+  {
+    uint8_t bytes[RX_MESSAGE_LENGTH];
+    std::memcpy(bytes, REAL_UNIT_C0_REPLY, RX_MESSAGE_LENGTH);
+    bytes[0] = 0x00;
+    expect("bad preamble is rejected", from_bytes(bytes).is_valid(), false);
+  }
+
+  // A bad prologue must be rejected.
+  {
+    uint8_t bytes[RX_MESSAGE_LENGTH];
+    std::memcpy(bytes, REAL_UNIT_C0_REPLY, RX_MESSAGE_LENGTH);
+    bytes[31] = 0x00;
+    expect("bad prologue is rejected", from_bytes(bytes).is_valid(), false);
+  }
+
+  std::printf("\n%d checks, %d failure(s)\n", g_checks, g_failures);
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

A real **MD17I-017HW** indoor unit on a live 5-indoor-unit Mini VRF system (outdoor **MD17I-004C / GDV-V160W**) was captured replying to every `C0` QUERY, but every response was rejected:

```
<<< AA C0 80 00 01 00 E0 14 00 00 18 5C 34 36 FF FF 00 00 00 01 00 00 00 00 00 00 00 0A FF FF E6 55
[E][midea_xye:327]: Received invalid response from AC
```

The frame is well-formed — correct preamble (`AA`), prologue (`55`), and CRC (`0xE6`, hand-verified) — and carries live data (room temp 26 °C, target 24 °C, compressor active, no faults). The only problem: this unit sets the **direction byte to `0x80`** (bit 7 = "this is a reply") instead of `0x00`.

`ReceiveData::is_valid()` compared that byte against `Direction::TO_CLIENT` (defined as `0x00`) exactly, so the whole frame was dropped and the unit never came online.

## Fix

Mask off bit 7 before the direction comparison, so both the `0x00` and `0x80` reply encodings validate. No behavior change for units that already reply with `0x00`.

## Tests

- New `tests/native/test_is_valid.cpp` built from the **exact captured frame**: asserts the `0x80` reply validates, a plain `0x00` reply validates, and corrupted CRC / preamble / prologue are still rejected. The first assertion fails against the old code — genuine regression coverage.
- Wired into the `native-tests` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)