### PR TITLE
fix: publish current temperature even when unit reports OFF

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -364,16 +364,20 @@ void ClimateMideaXYE::ParseResponse() {
         }
       }
 
+      // The indoor coil/room temperature (t1) is a physical reading that is valid whether
+      // or not the unit is actively conditioning, so it must be published on every valid C0
+      // response — not gated on mode. Otherwise, with no follow-me sensor supplying
+      // current_temperature through a separate path, Home Assistant sees null whenever the
+      // unit reads OFF (which, on some VRF indoor units, is what C0 reports even while running).
+      this->internal_temperature_ = XYEAdapter::get_temperature(qr.t1_temperature.value);
+
+      // Publish the internal temperature to the sensor if configured
+      set_sensor(this->internal_current_temperature_sensor_, this->internal_temperature_);
+
+      // Update current_temperature based on sensor availability
+      this->update_current_temperature_from_sensors_(need_publish);
+
       if (mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) {
-        // Store the internal temperature from the XYE bus
-        this->internal_temperature_ = XYEAdapter::get_temperature(qr.t1_temperature.value);
-
-        // Publish the internal temperature to the sensor if configured
-        set_sensor(this->internal_current_temperature_sensor_, this->internal_temperature_);
-
-        // Update current_temperature based on sensor availability
-        this->update_current_temperature_from_sensors_(need_publish);
-
         // Target temperature is read from C4 (QUERY_EXTENDED) by default. Opt-in
         // (target_temperature_from_c0): read it from this C0 frame instead, for units
         // that never answer C4 (e.g. some Mini VRF indoor units) and would otherwise leave


### PR DESCRIPTION
## Problem

With no `follow_me_sensor` configured, Home Assistant shows a **null current temperature** — including while the unit is running.

Root cause: in the C0 `QUERY` handler, the indoor coil/room temperature (`t1`) was only decoded inside the `if (mode != OFF || ForceReadNextCycle == 1)` gate, and `internal_temperature_` defaults to `NAN`. On this Mini VRF (outdoor MD17I-004C / GDV-V160W, indoor MD17I-017HW) the C0 `operation_mode` byte reads `0x00` (OFF) even while the unit is on — a real capture showed `operation_mode=0x00` alongside a valid `t1=0x5C`. So the gate is never entered, `update_current_temperature_from_sensors_()` is never called, and `current_temperature` (and the `internal_current_temperature` sensor) stay `NAN` → null in HA.

A configured follow-me sensor masked the bug by updating `current_temperature` through a separate, ungated path (`on_follow_me_sensor_update_`).

## Fix

Move the `t1` read and the `current_temperature` update out of the mode gate so they run on every valid C0 frame. `t1` is a physical thermistor reading, valid whether or not the unit is conditioning. Target-temperature / action / swing / preset logic stays gated on mode.

## Risk

- **Follow-me users: unaffected.** `update_current_temperature_from_sensors_()` keeps strict priority for the follow-me sensor; the extra calls just re-assert the same value (no-op via `update_property`). Fallback to internal `t1` only occurs in the window where the follow-me sensor has no valid state — a safer fallback than null.
- `to_celsius()` is pure arithmetic and never returns `NaN`, so `t1` always decodes to a finite value.
- Behavioral change: users who relied on current-temp going null while the AC is off will now see the live room temperature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)