### PR TITLE
feat: add target_temperature_from_c0 opt-in to read setpoint from C0

### DIFF
--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -70,6 +70,7 @@ CONF_COMPRESSOR_ACTIVE = "compressor_active"
 CONF_FAN_SPEED = "fan_speed"
 CONF_COMPRESSOR_AWARE_ACTION = "compressor_aware_action"
 CONF_SYNC_FAN_MODE_FROM_DEVICE = "sync_fan_mode_from_device"
+CONF_TARGET_TEMPERATURE_FROM_C0 = "target_temperature_from_c0"
 CONF_AUTO_DISCOVER = "auto_discover"
 CONF_DISCOVERY_AFTER = "discovery_after"
 CONF_DISCOVERED_ADDRESS = "discovered_address"
@@ -158,6 +159,10 @@ CONFIG_SCHEMA = cv.All(
             # physical thermostat), so Home Assistant reflects fan mode changes even when
             # not triggered by an HA command.
             cv.Optional(CONF_SYNC_FAN_MODE_FROM_DEVICE, default=False): cv.boolean,
+            # Opt-in: read the target setpoint from the C0 (QUERY) response instead of C4
+            # (QUERY_EXTENDED). For units that never answer C4 and would otherwise report a
+            # null target temperature. C0 carries the setpoint in the same encoding C4 uses.
+            cv.Optional(CONF_TARGET_TEMPERATURE_FROM_C0, default=False): cv.boolean,
             # Opt-in: if the configured address is unresponsive for `discovery_after`
             # poll cycles, sweep the address range with read-only C0 probes and adopt
             # the first unit that answers. For an isolated one-unit-per-ESP bus.
@@ -417,6 +422,7 @@ async def to_code(config):
     cg.add(var.set_use_fahrenheit(config[CONF_USE_FAHRENHEIT]))
     cg.add(var.set_compressor_aware_action(config[CONF_COMPRESSOR_AWARE_ACTION]))
     cg.add(var.set_sync_fan_mode_from_device(config[CONF_SYNC_FAN_MODE_FROM_DEVICE]))
+    cg.add(var.set_target_temperature_from_c0(config[CONF_TARGET_TEMPERATURE_FROM_C0]))
     if CONF_TRANSMITTER_ID in config:
         cg.add_define("USE_REMOTE_TRANSMITTER")
         transmitter_ = await cg.get_variable(config[CONF_TRANSMITTER_ID])

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -366,8 +366,19 @@ void ClimateMideaXYE::ParseResponse() {
         // Update current_temperature based on sensor availability
         this->update_current_temperature_from_sensors_(need_publish);
 
-        // Target temperature is read exclusively from C4 (QUERY_EXTENDED) to handle both
-        // Celsius and Fahrenheit encodings consistently. C0 target_temperature is not used.
+        // Target temperature is read from C4 (QUERY_EXTENDED) by default. Opt-in
+        // (target_temperature_from_c0): read it from this C0 frame instead, for units
+        // that never answer C4 (e.g. some Mini VRF indoor units) and would otherwise leave
+        // target_temperature null. C0 carries the setpoint in the same encoding
+        // get_target_temperature() decodes for C4 — Celsius raw with the 0x40 status flag,
+        // or (°F + FAHRENHEIT_TEMP_OFFSET) in Fahrenheit mode. Respect post_set_grace_ so a
+        // freshly-sent SET is not immediately overwritten by stale device state. When enabled,
+        // the C4 handler skips its own target read so the two sources never fight.
+        if (this->target_temperature_from_c0_ && post_set_grace_ == 0) {
+          update_property(this->target_temperature,
+                          XYEAdapter::get_target_temperature(qr.target_temperature.value, this->use_fahrenheit_),
+                          need_publish);
+        }
 
         // Compressor/defrost-aware action is opt-in (compressor_aware_action) while the
         // C0 byte-19 compressor flag is still provisional. When disabled, compressor_active=true
@@ -420,13 +431,16 @@ void ClimateMideaXYE::ParseResponse() {
       const auto &exr = rx_data.message.data.extended_query_response;
       set_sensor(this->outdoor_sensor_, XYEAdapter::get_temperature(exr.outdoor_temperature.value));
       set_number(this->static_pressure_number_, static_cast<float>(STATIC_PRESSURE_VALUE_MASK & exr.static_pressure));
-      // C4 is the sole source for target_temperature, covering both unit modes:
+      // C4 is the default source for target_temperature, covering both unit modes:
       //  - Fahrenheit: encoded as (°F + FAHRENHEIT_TEMP_OFFSET); convert to Celsius for ESPHome.
       //  - Celsius:    raw integer degrees with bit 6 (0x40) status flag; mask before use.
       // Respect post_set_grace_: skip until the C0 grace window has closed so a freshly-sent
       // SET command isn't immediately overwritten by stale device state.
+      // When target_temperature_from_c0 is opted into, C0 is authoritative for the setpoint,
+      // so skip the C4 read here to avoid the two sources fighting.
       // Fahrenheit C4 decode approach adapted from rmounce/esphome@xye-units-switch.
-      if ((this->mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) &&
+      if (!this->target_temperature_from_c0_ &&
+          (this->mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) &&
           post_set_grace_ == 0) {
         const float incoming_target_temp =
             XYEAdapter::get_target_temperature(exr.target_temperature.value, this->use_fahrenheit_);

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -163,6 +163,10 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   /// Opt-in: when true, this->fan_mode is updated from C4 target_fan_speed on every extended
   /// query cycle, reflecting the fan setting on the physical thermostat in Home Assistant.
   void set_sync_fan_mode_from_device(bool yesno) { this->sync_fan_mode_from_device_ = yesno; }
+  /// Opt-in: when true, the target setpoint is read from the C0 (QUERY) response instead of
+  /// C4 (QUERY_EXTENDED). For units that never answer C4 and would otherwise report a null
+  /// target temperature. The C4 handler skips its target read while this is enabled.
+  void set_target_temperature_from_c0(bool yesno) { this->target_temperature_from_c0_ = yesno; }
   void set_static_pressure_number(StaticPressureNumber *number) {
     this->static_pressure_number_ = number;
     number->set_parent(this);
@@ -248,6 +252,9 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   // Opt-in (sync_fan_mode_from_device YAML option): when true, fan_mode is updated from C4
   // target_fan_speed (the commanded speed from the physical thermostat).
   bool sync_fan_mode_from_device_{false};
+  // Opt-in (target_temperature_from_c0 YAML option): when true, the setpoint is read from the
+  // C0 (QUERY) response instead of C4 (QUERY_EXTENDED), for units that never answer C4.
+  bool target_temperature_from_c0_{false};
   Sensor *outdoor_sensor_{nullptr};
   Sensor *fan_speed_sensor_{nullptr};
   Sensor *temperature_2a_sensor_{nullptr};

--- a/tests/midea_xye.yaml
+++ b/tests/midea_xye.yaml
@@ -55,6 +55,7 @@ climate:
       name: "Compressor Active"
     compressor_aware_action: true
     sync_fan_mode_from_device: true
+    target_temperature_from_c0: true
 
 # Temperature sensor required for follow_me
 sensor:


### PR DESCRIPTION
## Problem

`target_temperature` has been read **exclusively from C4** (`QUERY_EXTENDED`) since #127. Some Mini VRF indoor units (outdoor MD17I-004C / GDV-V160W, indoor MD17I-017HW) never answer C4, so the setpoint stays `NaN` → Home Assistant reports a **null target temperature** and disables the setpoint dial.

Those units *do* answer C0 (`QUERY`), which carries the setpoint. Confirmed on a live unit:

```
operation_mode:     0x88 (COOL)
target_temperature: 0x1B (27.00°C)   ← valid setpoint, in the C0 frame
```

C0 uses the **same encoding** `get_target_temperature()` already decodes for C4 (Celsius raw + 0x40 status flag, or `°F + FAHRENHEIT_TEMP_OFFSET` in Fahrenheit mode), so the Fahrenheit mis-decode that motivated #127's C4-only switch no longer applies.

## Change

New opt-in boolean **`target_temperature_from_c0`** (default `false` — existing behavior unchanged). When `true`:
- the C0 handler decodes `qr.target_temperature` and publishes it, respecting the `post_set_grace_` window so a freshly-sent SET isn't clobbered;
- the C4 handler skips its own target read so the two sources never fight.

## Wiring
- `climate.py`: `CONF_TARGET_TEMPERATURE_FROM_C0`, schema entry (`cv.boolean`, default `False`), `to_code` setter call.
- `climate_midea_xye.h`: `set_target_temperature_from_c0()` + `target_temperature_from_c0_{false}` member.
- `climate_midea_xye.cpp`: C0 read + C4 skip.
- Exercised in `tests/midea_xye.yaml`.

## Usage
```yaml
climate:
  - platform: midea_xye
    target_temperature_from_c0: true   # for units that never answer C4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)