### PR TITLE
fix: publish discovered_address whenever a unit answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ climate:
                                 # a CCM/other controller.
     discovery_after: 10         # Optional. Defaults to 10. Consecutive unanswered polls
                                 # before an address sweep starts.
-    discovered_address:         # Optional. Diagnostic sensor reporting the address
-      name: XYE Address         # auto-discovery locked onto (the unit's dial value).
+    discovered_address:         # Optional. Diagnostic sensor reporting the active unit
+      name: XYE Address         # address (the dial value). Published whenever a unit
+                                # answers, so it reflects both the configured address and
+                                # any address auto-discovery locks onto.
     period: 1s                  # Optional. Defaults to 1s
     timeout: 100ms              # Optional. Defaults to 100ms
     use_fahrenheit: false       # Optional. Defaults to false

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -144,6 +144,10 @@ void ClimateMideaXYE::sendRecv(uint8_t cmdSent) {
       // The configured address answered: the bus is responsive, clear the miss
       // counter so a transient gap never accumulates toward a needless sweep.
       this->miss_count_ = 0;
+      // A unit answered at the active address; surface it so the sensor never
+      // sits at "Unknown" for a unit that responds at its configured address
+      // (i.e. one that never triggered an auto-discovery sweep).
+      this->publish_discovered_address_();
       // Log incoming message at debug level
       rx_data.print_debug(i, Constants::TAG, ESPHOME_LOG_LEVEL_DEBUG, this->use_fahrenheit_);
       // Don't parse responses to SET or FOLLOW_ME commands to avoid
@@ -260,12 +264,16 @@ void ClimateMideaXYE::finish_discovery_(bool found, uint8_t addr) {
     ESP_LOGI(Constants::TAG, "Discovered unit at address 0x%02X (was polling 0x%02X); adopting it", addr,
              this->address_);
     this->address_ = addr;
-    set_sensor(this->discovered_address_sensor_, static_cast<float>(addr));
+    this->publish_discovered_address_();
   } else {
     ESP_LOGW(Constants::TAG, "Address scan found no unit in 0x%02X-0x%02X; resuming polls at 0x%02X",
              this->scan_min_, this->scan_max_, this->address_);
   }
   this->controlState = ControlState::SEND_QUERY;
+}
+
+void ClimateMideaXYE::publish_discovered_address_() {
+  set_sensor(this->discovered_address_sensor_, static_cast<float>(this->address_));
 }
 
 void ClimateMideaXYE::update() {

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -182,6 +182,11 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   void maybe_start_discovery_();
   void send_probe_();
   void finish_discovery_(bool found, uint8_t addr);
+  // Publish the currently active unit address to the discovered_address sensor.
+  // Called whenever a unit answers at the active address, so the sensor reflects
+  // the live address instead of only being set when an auto-discovery sweep
+  // adopts a new one (which never happens for a unit at its configured address).
+  void publish_discovered_address_();
   void setPowerState(bool state);
   void setTransmitParams();
 


### PR DESCRIPTION
## Summary

The `discovered_address` diagnostic sensor was only published from `finish_discovery_()` — i.e. only when the opt-in auto-discovery **sweep** adopted a new address. A unit that answers at its **configured** address never triggers a sweep, so the sensor was never published and Home Assistant showed it as **"Unknown"**.

This publishes the active address on every confirmed poll response, so a unit sitting at its configured address reports its real address instead of "Unknown". The publish is factored into a `publish_discovered_address_()` helper reused by the discovery path.

## Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Unit answers at configured address | "Unknown" | its configured address |
| Unit found via discovery sweep | adopted address | adopted address (unchanged) |
| Unit that never answers | "Unknown" | "Unknown" (correct) |

The sensor stays a numeric `sensor`; no config change. A follow-up PR converts it to a `text_sensor` to drop the float (`3.0`) display.

## Testing

- `esphome config` schema validation passes for both `tests/midea_xye.yaml` and `tests/midea_xye_esp32.yaml` (both already exercise `discovered_address:`). Full `esphome compile` left to CI — the pinned `esphome==2026.4.0` was not installable in the dev sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)