### PR TITLE
feat!: report discovered_address as an integer text sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ climate:
                                 # a CCM/other controller.
     discovery_after: 10         # Optional. Defaults to 10. Consecutive unanswered polls
                                 # before an address sweep starts.
-    discovered_address:         # Optional. Diagnostic sensor reporting the active unit
-      name: XYE Address         # address (the dial value). Published whenever a unit
-                                # answers, so it reflects both the configured address and
-                                # any address auto-discovery locks onto.
+    discovered_address:         # Optional. Diagnostic text sensor reporting the active
+      name: XYE Address         # unit address (the dial value) as an integer string.
+                                # Published whenever a unit answers, so it reflects both
+                                # the configured address and any address auto-discovery
+                                # locks onto.
     period: 1s                  # Optional. Defaults to 1s
     timeout: 100ms              # Optional. Defaults to 100ms
     use_fahrenheit: false       # Optional. Defaults to false

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -1,6 +1,6 @@
 from esphome.core import coroutine
 from esphome import automation
-from esphome.components import binary_sensor, climate, sensor, uart, remote_transmitter, number
+from esphome.components import binary_sensor, climate, sensor, text_sensor, uart, remote_transmitter, number
 from esphome.components.remote_base import CONF_TRANSMITTER_ID
 import esphome.config_validation as cv
 import esphome.codegen as cg
@@ -50,7 +50,7 @@ from esphome.components.climate import (
 
 #CODEOWNERS = ["@dudanov"]
 DEPENDENCIES = ["climate", "uart", "wifi"]
-AUTO_LOAD = ["binary_sensor", "number", "sensor"]
+AUTO_LOAD = ["binary_sensor", "number", "sensor", "text_sensor"]
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
 CONF_TEMPERATURE_2A = "temperature_2a"
 CONF_TEMPERATURE_2B = "temperature_2b"
@@ -204,10 +204,11 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
-            # Publishes the unit address that auto-discovery locked onto (its dial value).
-            cv.Optional(CONF_DISCOVERED_ADDRESS): sensor.sensor_schema(
+            # Publishes the active unit address as an integer string (its dial
+            # value). A text sensor keeps it an integer end-to-end instead of a
+            # numeric sensor that renders the address as a float ("3.0").
+            cv.Optional(CONF_DISCOVERED_ADDRESS): text_sensor.text_sensor_schema(
                 icon="mdi:identifier",
-                accuracy_decimals=0,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(
@@ -452,7 +453,7 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_FAN_SPEED])
         cg.add(var.set_fan_speed_sensor(sens))
     if CONF_DISCOVERED_ADDRESS in config:
-        sens = await sensor.new_sensor(config[CONF_DISCOVERED_ADDRESS])
+        sens = await text_sensor.new_text_sensor(config[CONF_DISCOVERED_ADDRESS])
         cg.add(var.set_discovered_address_sensor(sens))
     if CONF_TEMPERATURE_2A in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_2A])

--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -18,6 +18,11 @@ static void set_sensor(Sensor *sensor, float value) {
     sensor->publish_state(value);
 }
 
+static void set_text_sensor(TextSensor *sensor, const std::string &value) {
+  if (sensor != nullptr && (!sensor->has_state() || sensor->state != value))
+    sensor->publish_state(value);
+}
+
 static void set_number(number::Number *number, float value) {
   if (number != nullptr && (!number->has_state() || number->state != value))
     number->publish_state(value);
@@ -273,7 +278,10 @@ void ClimateMideaXYE::finish_discovery_(bool found, uint8_t addr) {
 }
 
 void ClimateMideaXYE::publish_discovered_address_() {
-  set_sensor(this->discovered_address_sensor_, static_cast<float>(this->address_));
+  // Publish as a decimal integer string (the dial value, 0..0x3F). A text
+  // sensor keeps it an integer end-to-end instead of a float that renders as
+  // "3.0" the way a numeric sensor would.
+  set_text_sensor(this->discovered_address_sensor_, std::to_string(static_cast<int>(this->address_)));
 }
 
 void ClimateMideaXYE::update() {

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -6,6 +6,7 @@
 #include "esphome/components/climate/climate_traits.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -101,6 +102,7 @@ using climate::ClimateMode;
 using climate::ClimatePreset;
 using climate::ClimateSwingMode;
 using sensor::Sensor;
+using text_sensor::TextSensor;
 
 class Constants {
  public:
@@ -131,7 +133,7 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   /// unit that answers. Intended for an isolated one-unit-per-ESP bus.
   void set_auto_discover(bool yesno) { this->auto_discover_ = yesno; }
   void set_discovery_after(uint16_t cycles) { this->discovery_after_ = cycles; }
-  void set_discovered_address_sensor(Sensor *sensor) { this->discovered_address_sensor_ = sensor; }
+  void set_discovered_address_sensor(TextSensor *sensor) { this->discovered_address_sensor_ = sensor; }
 
   /* Component methods */
 
@@ -279,7 +281,7 @@ class ClimateMideaXYE : public PollingComponent, public climate::Climate, public
   Sensor *follow_me_sensor_{nullptr};
   Sensor *internal_current_temperature_sensor_{nullptr};
   // Publishes the address auto-discovery locked onto (the unit's dial value).
-  Sensor *discovered_address_sensor_{nullptr};
+  TextSensor *discovered_address_sensor_{nullptr};
   StaticPressureNumber *static_pressure_number_{nullptr};
   ClimateMode last_on_mode_;
   float internal_temperature_{NAN};


### PR DESCRIPTION
## Summary

Stacked on #154. A numeric ESPHome `sensor` is always a float in Home Assistant, so the `discovered_address` unit address rendered with a decimal (`3.0`). This converts it to a `text_sensor` that publishes the address as a plain integer string (`3`), keeping it an integer end-to-end.

Depends on #154 (the publish-on-answer fix) — **merge #154 first**, then this.

## Changes

- `climate.py`: `discovered_address` schema → `text_sensor.text_sensor_schema`, codegen → `text_sensor.new_text_sensor`, added `text_sensor` to imports and `AUTO_LOAD`.
- `climate_midea_xye.{h,cpp}`: member/setter → `TextSensor *`; `publish_discovered_address_()` now publishes `std::to_string(address_)`.
- `README.md`: describe it as a text sensor reporting an integer string.

## ⚠️ Breaking change

`discovered_address` is now a `text_sensor` instead of a numeric `sensor`:
- Its state changes from a number to a string.
- Any `accuracy_decimals` / `state_class` / `unit_of_measurement` set on it in YAML must be removed.

`release-please` will pick this up as a **major** bump from the `feat!` / `BREAKING CHANGE:` footer.

## Testing

- `esphome config` schema validation passes for both `tests/midea_xye.yaml` and `tests/midea_xye_esp32.yaml` (both exercise `discovered_address:` with just `name:`, which is valid for a text sensor). Full `esphome compile` left to CI — the pinned `esphome==2026.4.0` was not installable in the dev sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)