### PR TITLE
fix: render discovered_address as an integer in Home Assistant

### DIFF
--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -205,9 +205,12 @@ CONFIG_SCHEMA = cv.All(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             # Publishes the unit address that auto-discovery locked onto (its dial value).
+            # state_class is required for Home Assistant to honour accuracy_decimals=0;
+            # without it HA ignores the precision hint and renders the raw float ("1.0").
             cv.Optional(CONF_DISCOVERED_ADDRESS): sensor.sensor_schema(
                 icon="mdi:identifier",
                 accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(


### PR DESCRIPTION
## Summary

`discovered_address` set `accuracy_decimals=0`, but Home Assistant still displayed the address as `1.0`. HA only applies a sensor's suggested display precision when the sensor has a `state_class` (or a numeric `device_class`) — and `discovered_address` was the **only** numeric sensor in the component without one. Every other diagnostic sensor (`fan_speed`, `error_flags`, `protect_flags`, …) already sets `state_class: measurement` and renders as an integer.

This adds `state_class: measurement` so HA honours `accuracy_decimals=0` and shows the address as `1` instead of `1.0`.

Stays a numeric `sensor` — no breaking change, no config change required.

## Trade-off

`state_class: measurement` makes HA record long-term statistics for the address. Harmless (the value rarely changes), and consistent with the other diagnostic sensors here.

## Testing

- `esphome config` schema validation passes for `tests/midea_xye.yaml` / `tests/midea_xye_esp32.yaml` (the only error is the unrelated 2026.x `wifi.min_auth_mode` key not present in the sandbox's esphome). Full `esphome compile` left to CI — the pinned `esphome==2026.4.0` was not installable in the dev sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)