### PR TITLE
docs: credit Sergey Kudrin for the CCM03 F1/F2 investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Kudos to these projects and people:
 - Static pressure protocol analysis by @rmounce
 - C&H "Sophia Hyper" concealed-duct raw-temperature/C0-setpoint research by @larsonm-personal
 - Home Assistant community discussion and contributions: https://community.home-assistant.io/t/midea-a-c-via-local-xye/857679
+- CCM03 `F1/F2` gateway-port investigation and recovery of genuine legacy Midea/MDV
+  NetAC (`ACServer`) frames by Sergey Kudrin — evidence that the CCM03's PC/gateway
+  port carries XYE framing at 9600 8N1 rather than a separate protocol. See
+  [PROTOCOL.md → Acknowledgments](esphome/components/midea_xye/PROTOCOL.md#acknowledgments).
 - S1/S2 bus (IDU ↔ outdoor inverter) reverse-engineering by MidATRIX:
   https://github.com/MidATRIX/midea-s1s2-rs485-monitor — a sibling Midea RS-485
   protocol on a different bus, useful as a cross-reference for the sensor fields and

--- a/esphome/components/midea_xye/PROTOCOL.md
+++ b/esphome/components/midea_xye/PROTOCOL.md
@@ -13,6 +13,17 @@ This documentation is based on:
 - ESPHome Midea component: https://github.com/esphome/esphome/tree/dev/esphome/components/midea
 - HA Community thread reverse-engineering by mdrobnak, rymo, and others: https://community.home-assistant.io/t/midea-a-c-via-local-xye/857679 ([archived PDF](https://github.com/user-attachments/files/26555742/Midea.A_C.via.local.XYE.-.ESPHome.-.Home.Assistant.Community.pdf))
 - S1/S2 bus reverse-engineering by MidATRIX: https://github.com/MidATRIX/midea-s1s2-rs485-monitor — different bus (IDU↔ODU), same RS-485 medium, useful field-level cross-reference. See [Related Protocols](#related-protocols--s1s2-bus-iduodu).
+- CCM03 `F1/F2` gateway-port investigation by Sergey Kudrin, who obtained the original
+  legacy Midea/MDV **NetAC** software package (`NetACControlFBD` / `ACServer`) and
+  extracted genuine legacy `F1/F2` request and response frames from it. Those frames
+  validate against the framing, addressing and CRC rules documented here — 16-byte
+  query, 32-byte response, `0xAA`/`0x55`, command echoed in the reply, the `0x80`
+  reply marker in response byte 2, and a correct CRC under
+  [CRC Calculation](#crc-calculation) — which indicates the CCM03's PC/gateway port
+  speaks XYE at **9600 8N1**, not a separate upper-layer protocol as the terminal
+  labelling suggests. The frames also carry command `0xC1`, which this component does
+  not implement (see [Commands](#commands)). Software-extracted rather than captured
+  on the wire; on-wire confirmation on a live VRF system is pending.
 
 ## Physical Layer
 


### PR DESCRIPTION
## Summary

Credits Sergey Kudrin for the CCM03 `F1/F2` gateway-port investigation.

Kudrin obtained the original legacy Midea/MDV **NetAC** software package (`NetACControlFBD` / `ACServer`) from Dantex and extracted genuine legacy `F1/F2` request and response frames from it. Those frames validate against the framing, addressing and CRC rules already documented in `PROTOCOL.md`:

- 16-byte query, 32-byte response
- `0xAA` preamble / `0x55` prologue
- command echoed in the reply
- `0x80` reply marker in response byte 2 (the legacy "this is a reply" bit this component already handles)
- correct CRC under the rule in `CRC Calculation`

This indicates the CCM03's PC/gateway port speaks XYE at **9600 8N1** rather than the separate upper-layer protocol its `F1/F2` terminal labelling implies. The frames also carry command `0xC1`, which this component does not implement.

## Status of the evidence

Recorded as **software-extracted, not captured on the wire**. On-wire confirmation on a live VRF system is pending, and the acknowledgment text says so. If live captures land, the finding likely warrants its own `PROTOCOL.md` section rather than living in acknowledgments.

## Changes

- `README.md` — acknowledgments entry.
- `PROTOCOL.md` — acknowledgments entry with the supporting detail.

Documentation only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)