### PR TITLE
Fix Follow Me Temperature Presentation

### DIFF
--- a/esphome/components/midea_xye/climate_midea_xye.cpp
+++ b/esphome/components/midea_xye/climate_midea_xye.cpp
@@ -689,7 +689,11 @@ void ClimateMideaXYE::update_current_temperature_from_sensors_(bool &need_publis
   // Use follow_me_sensor as current_temperature if available, otherwise use internal temperature
   if (this->follow_me_sensor_ != nullptr && this->follow_me_sensor_->has_state() &&
       !std::isnan(this->follow_me_sensor_->state)) {
-    update_property(this->current_temperature, this->follow_me_sensor_->state, need_publish);
+    const float sensor_temperature = this->use_fahrenheit_
+                                         ? (this->follow_me_sensor_->state - FAHRENHEIT_CELSIUS_OFFSET) *
+                                               FAHRENHEIT_TO_CELSIUS_SCALE
+                                         : this->follow_me_sensor_->state;
+    update_property(this->current_temperature, sensor_temperature, need_publish);
   } else if (!std::isnan(this->internal_temperature_)) {
     update_property(this->current_temperature, this->internal_temperature_, need_publish);
   }

--- a/esphome/components/midea_xye/climate_midea_xye.h
+++ b/esphome/components/midea_xye/climate_midea_xye.h
@@ -91,6 +91,11 @@ constexpr uint8_t CAPABILITIES_SWING = static_cast<uint8_t>(xye::Capabilities::S
 /// Applies to both the XYE-bus internal temperature and any external follow_me sensor value.
 constexpr float VISUAL_CURRENT_TEMPERATURE_STEP = 0.01f;
 
+/// Fahrenheit temperature offset used when converting a Follow-Me sensor value for ESPHome.
+constexpr float FAHRENHEIT_CELSIUS_OFFSET = 32.0f;
+/// Fahrenheit-to-Celsius scale used when converting a Follow-Me sensor value for ESPHome.
+constexpr float FAHRENHEIT_TO_CELSIUS_SCALE = 5.0f / 9.0f;
+
 constexpr uint8_t OP_FLAG_WATER_PUMP = static_cast<uint8_t>(xye::OperationFlags::WATER_PUMP);
 constexpr uint8_t OP_FLAG_WATER_LOCK = static_cast<uint8_t>(xye::OperationFlags::WATER_LOCK);
 


### PR DESCRIPTION
If you live in a part of the world that uses Fahrenheit, the Follow Me temperature reported to the Climate Module will be in Fahrenheit, but report the unit as Celsius, resulting in Home Assistant reporting that your home is above boiling when it's actually not that bad.

The issue stems from a missing unit conversion as the climate module reports in Celsius, but the temperature from the Follow Me sensor is not converted before the value is inserted. This change ensures that the necessary conversions are done to have the value match the units.


_AI made the change, but it was reviewed by a human. A human drafted this PR Description._